### PR TITLE
Replace links to dfe-digital with x-govuk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # GOV.UK Components
 
-[![Tests](https://github.com/DFE-Digital/govuk-components/workflows/Tests/badge.svg)](https://github.com/DFE-Digital/govuk-components/actions?query=workflow%3ATests)
-[![Maintainability](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/maintainability)](https://codeclimate.com/github/DFE-Digital/govuk-components/maintainability)
+[![Tests](https://github.com/x-govuk/govuk-components/workflows/Tests/badge.svg)](https://github.com/x-govuk/govuk-components/actions?query=workflow%3ATests)
+[![Maintainability](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/maintainability)](https://codeclimate.com/github/x-govuk/govuk-components/maintainability)
 [![Gem Version](https://badge.fury.io/rb/govuk-components.svg)](https://badge.fury.io/rb/govuk-components)
 [![Gem](https://img.shields.io/gem/dt/govuk-components?logo=rubygems)](https://rubygems.org/gems/govuk-components)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk-components/test_coverage)
-[![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk-components)](https://github.com/DFE-Digital/govuk-components/blob/main/LICENSE)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/test_coverage)](https://codeclimate.com/github/x-govuk/govuk-components/test_coverage)
+[![GitHub license](https://img.shields.io/github/license/x-govuk/govuk-components)](https://github.com/x-govuk/govuk-components/blob/main/LICENSE)
 [![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.6.0-brightgreen)](https://design-system.service.gov.uk)
 [![Rails](https://img.shields.io/badge/Rails-6.1.7%20%E2%95%B1%207.0.3-E16D6D)](https://weblog.rubyonrails.org/releases/)
 [![Ruby](https://img.shields.io/badge/Ruby-3.0.5%20%20%E2%95%B1%203.1.3%20%20%E2%95%B1%203.2.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)

--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -3,11 +3,11 @@ $LOAD_PATH.push File.expand_path("lib", __dir__)
 require "govuk/components/version"
 
 METADATA = {
-  "bug_tracker_uri"   => "https://github.com/DFE-Digital/govuk-components/issues",
-  "changelog_uri"     => "https://github.com/DFE-Digital/govuk-components/releases",
+  "bug_tracker_uri"   => "https://github.com/x-govuk/govuk-components/issues",
+  "changelog_uri"     => "https://github.com/x-govuk/govuk-components/releases",
   "documentation_uri" => "https://www.rubydoc.info/gems/govuk-components/",
-  "homepage_uri"      => "https://github.com/DFE-Digital/govuk-components",
-  "source_code_uri"   => "https://github.com/DFE-Digital/govuk-components"
+  "homepage_uri"      => "https://github.com/x-govuk/govuk-components",
+  "source_code_uri"   => "https://github.com/x-govuk/govuk-components"
 }.freeze
 
 Gem::Specification.new do |spec|
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.version     = Govuk::Components::VERSION
   spec.authors     = ["DfE developers"]
   spec.email       = ["peter.yates@digital.education.gov.uk"]
-  spec.homepage    = "https://github.com/DFE-Digital/govuk-components"
+  spec.homepage    = "https://github.com/x-govuk/govuk-components"
   spec.summary     = "Lightweight set of reusable GOV.UK Design System components"
   spec.description = "A collection of components intended to ease the building of GOV.UK Design System web applications"
   spec.license     = "MIT"

--- a/guide/content/introduction/configuration.slim
+++ b/guide/content/introduction/configuration.slim
@@ -24,4 +24,4 @@ pre
 
 markdown:
   You can see a full list of the configurable options in
-  [engine.rb](https://github.com/DFE-Digital/govuk-components/blob/main/lib/govuk/components/engine.rb).
+  [engine.rb](https://github.com/x-govuk/govuk-components/blob/main/lib/govuk/components/engine.rb).

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -38,7 +38,7 @@ module Helpers
     end
 
     def github_link
-      'https://github.com/DFE-Digital/govuk-components'
+      'https://github.com/x-govuk/govuk-components'
     end
 
     def rubygems_link
@@ -50,7 +50,7 @@ module Helpers
     end
 
     def code_climate_report_link
-      'https://codeclimate.com/github/DFE-Digital/govuk-components'
+      'https://codeclimate.com/github/x-govuk/govuk-components'
     end
 
     def dfe_rails_boilerplate_link

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
         <%= yield %>
       </main>
     </div>
-    <%= govuk_footer(meta_items: { "GitHub" => "https://github.com/DFE-Digital/govuk-components", "RubyGems" => "https://rubygems.org/gems/govuk-components", "DfE Digital" => "https://dfedigital.blog.gov.uk/" }) %>
+    <%= govuk_footer(meta_items: { "GitHub" => "https://github.com/x-govuk/govuk-components", "RubyGems" => "https://rubygems.org/gems/govuk-components", "DfE Digital" => "https://dfedigital.blog.gov.uk/" }) %>
   <script>
     window.GOVUKFrontend.initAll();
   </script>


### PR DESCRIPTION
The redirects are causing Nanoc's link checker to fail and preventing changes to the guide being published.
