### PR TITLE
Add support for inverted breadcrumbs and back links

### DIFF
--- a/app/components/govuk_component/back_link_component.rb
+++ b/app/components/govuk_component/back_link_component.rb
@@ -1,9 +1,10 @@
 class GovukComponent::BackLinkComponent < GovukComponent::Base
-  attr_reader :text, :href
+  attr_reader :text, :href, :inverse
 
-  def initialize(href:, text: config.default_back_link_text, classes: [], html_attributes: {})
+  def initialize(href:, inverse: false, text: config.default_back_link_text, classes: [], html_attributes: {})
     @text = text
     @href = href
+    @inverse = inverse
 
     super(classes: classes, html_attributes: html_attributes)
   end
@@ -19,6 +20,11 @@ private
   end
 
   def default_attributes
-    { class: %w(govuk-back-link) }
+    {
+      class: class_names(
+        "govuk-back-link",
+        "govuk-back-link--inverse" => inverse
+      ).split
+    }
   end
 end

--- a/app/components/govuk_component/breadcrumbs_component.rb
+++ b/app/components/govuk_component/breadcrumbs_component.rb
@@ -1,15 +1,17 @@
 class GovukComponent::BreadcrumbsComponent < GovukComponent::Base
-  attr_reader :breadcrumbs, :hide_in_print, :collapse_on_mobile
+  attr_reader :breadcrumbs, :hide_in_print, :collapse_on_mobile, :inverse
 
   def initialize(breadcrumbs:,
                  hide_in_print: config.default_breadcrumbs_hide_in_print,
                  collapse_on_mobile: config.default_breadcrumbs_collapse_on_mobile,
+                 inverse: false,
                  classes: [],
                  html_attributes: {})
 
     @breadcrumbs        = build_list(breadcrumbs)
     @hide_in_print      = hide_in_print
     @collapse_on_mobile = collapse_on_mobile
+    @inverse            = inverse
 
     super(classes: classes, html_attributes: html_attributes)
   end
@@ -21,7 +23,8 @@ private
       class: class_names(
         "govuk-breadcrumbs",
         "govuk-!-display-none-print" => hide_in_print,
-        "govuk-breadcrumbs--collapse-on-mobile" => collapse_on_mobile
+        "govuk-breadcrumbs--collapse-on-mobile" => collapse_on_mobile,
+        "govuk-breadcrumbs--inverse" => inverse
       ).split
     }
   end

--- a/guide/content/components/back-link.slim
+++ b/guide/content/components/back-link.slim
@@ -14,4 +14,13 @@ p
   caption: "Back link with custom text",
   code: back_link_custom)
 
+== render('/partials/example.*',
+  caption: "Back link with inverted colours",
+  code: back_link_inverse,
+  inverse: true) do
+
+  markdown:
+    When back links are displayed on darker backgrounds the `inverse` keyword argument can
+    be used to make them readable.
+
 == render('/partials/related-info.*', links: back_link_info)

--- a/guide/content/components/breadcrumbs.slim
+++ b/guide/content/components/breadcrumbs.slim
@@ -39,4 +39,14 @@ markdown:
     The `govuk_breadcrumb_link_to` helper generates links with the
     `govuk-breadcrumbs__link` class.
 
+== render('/partials/example.*',
+  caption: "Breadcrumbs with inverted colours",
+  code: breadcrumbs_inverted,
+  data: breadcrumbs_nav_hierarchy,
+  inverse: true) do
+
+  markdown:
+    When breadcrumbs are displayed on darker backgrounds the `inverse` keyword argument can
+    be used to make them readable.
+
 == render('/partials/related-info.*', links: breadcrumbs_info)

--- a/guide/lib/examples/back_link_helpers.rb
+++ b/guide/lib/examples/back_link_helpers.rb
@@ -11,5 +11,11 @@ module Examples
         = govuk_back_link(href: "/", text: "Return")
       BACK_LINK_NORMAL
     end
+
+    def back_link_inverse
+      <<~BACK_LINK_INVERSE
+        = govuk_back_link(href: "/", inverse: true)
+      BACK_LINK_INVERSE
+    end
   end
 end

--- a/guide/lib/examples/breadcrumbs_helpers.rb
+++ b/guide/lib/examples/breadcrumbs_helpers.rb
@@ -51,5 +51,24 @@ module Examples
         }
       BREADCRUMBS
     end
+
+    def breadcrumbs_inverted
+      <<~BREADCRUMBS
+        = govuk_breadcrumbs(breadcrumbs: breadcrumbs, inverse: true)
+      BREADCRUMBS
+    end
+
+    def breadcrumbs_nav_hierarchy
+      <<~BREADCRUMBS
+        {
+          breadcrumbs: [
+            govuk_breadcrumb_link_to("Home", "/"),
+            govuk_breadcrumb_link_to("Education and learning", "/"),
+            govuk_breadcrumb_link_to("Schools and curriculum", "/"),
+            govuk_breadcrumb_link_to("Early years foundation stage", "/")
+          ]
+        }
+      BREADCRUMBS
+    end
   end
 end

--- a/spec/components/govuk_component/back_link_component_spec.rb
+++ b/spec/components/govuk_component/back_link_component_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe(GovukComponent::BackLinkComponent, type: :component) do
     end
   end
 
+  context 'when back link colours are inverted' do
+    let(:kwargs) { { href: href, inverse: true } }
+    let(:expected_classes) { [component_css_class, "govuk-back-link--inverse"] }
+
+    specify 'renders the component with the inverted colour class present' do
+      expect(rendered_content).to have_tag('a', with: { href: href, class: expected_classes }, text: default_text)
+    end
+  end
+
   context 'when link text is provided via a block' do
     let(:custom_text) { "Some text" }
     let(:custom_tag) { :code }

--- a/spec/components/govuk_component/breadcrumbs_component_spec.rb
+++ b/spec/components/govuk_component/breadcrumbs_component_spec.rb
@@ -77,6 +77,15 @@ RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
     end
   end
 
+  context 'when breadcrumb colours are inverted' do
+    let(:kwargs) { { breadcrumbs: breadcrumbs, inverse: true } }
+    let(:expected_class) { 'govuk-breadcrumbs.govuk-breadcrumbs--inverse' }
+
+    specify 'breadcrumbs colours are inverted' do
+      expect(rendered_content).to have_tag('div', with: { class: %w(govuk-breadcrumbs govuk-breadcrumbs--inverse) })
+    end
+  end
+
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
 end


### PR DESCRIPTION
Support for inverting the colours on back links and breadcrumbs [was recently added](https://github.com/alphagov/govuk-frontend/pull/3774) to [govuk-frontend](https://github.com/alphagov/govuk-frontend), allowing them to be rendered on darker backgrounds in a legible way. This PR adds support to the relevant components by introducing a `inverse` keyword argument.


## Changes

- Add support for inverted breadcrumbs
- Add support for inverted back links

## Documentation

| Breadcrumbs | Back link |
| ----------------- | -------------- |
| ![Screenshot from 2023-06-25 10-30-05](https://github.com/x-govuk/govuk-components/assets/128088/d193e0f8-67d6-450b-a5db-631445f8feae) | ![Screenshot from 2023-06-25 10-31-36](https://github.com/x-govuk/govuk-components/assets/128088/9d881c15-9ace-464e-af31-8eb1bf961606) |


Fixes #428
