### PR TITLE
Consistent use of project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# GOV.UK Components
+# GOV.UK Components for Ruby on Rails
 
 [![Tests](https://github.com/x-govuk/govuk-components/workflows/Tests/badge.svg)](https://github.com/x-govuk/govuk-components/actions?query=workflow%3ATests)
 [![Maintainability](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/maintainability)](https://codeclimate.com/github/x-govuk/govuk-components/maintainability)
-[![Gem Version](https://badge.fury.io/rb/govuk-components.svg)](https://badge.fury.io/rb/govuk-components)
+[![Gem version](https://badge.fury.io/rb/govuk-components.svg)](https://badge.fury.io/rb/govuk-components)
 [![Gem](https://img.shields.io/gem/dt/govuk-components?logo=rubygems)](https://rubygems.org/gems/govuk-components)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/test_coverage)](https://codeclimate.com/github/x-govuk/govuk-components/test_coverage)
+[![Test coverage](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/test_coverage)](https://codeclimate.com/github/x-govuk/govuk-components/test_coverage)
 [![Licence](https://img.shields.io/github/license/x-govuk/govuk-components)](https://github.com/x-govuk/govuk-components/blob/main/LICENSE.txt)
-[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.6.0-brightgreen)](https://design-system.service.gov.uk)
+[![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.6.0-brightgreen)](https://design-system.service.gov.uk)
 [![Rails](https://img.shields.io/badge/Rails-6.1.7%20%E2%95%B1%207.0.3-E16D6D)](https://weblog.rubyonrails.org/releases/)
 [![Ruby](https://img.shields.io/badge/Ruby-3.0.5%20%20%E2%95%B1%203.1.3%20%20%E2%95%B1%203.2.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 
@@ -16,10 +16,7 @@ It aims to implement the functionality from the original Nunjucks macros in a wa
 
 ## Documentation
 
-The gem comes with [a full guide](https://govuk-components.netlify.app/) that
-covers most aspects of day-to-day use, along with code and output examples. The
-examples in the guide (and the guide itself) are built using the components,
-so it will always be up to date.
+The gem comes with [a full guide](https://govuk-components.netlify.app/) that covers most aspects of day-to-day use, along with code and output examples. The examples in the guide (and the guide itself) are built using the components, so it will always be up to date.
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/d40a5a0a-b086-4c35-b046-97fbcbf9f219/deploy-status)](https://app.netlify.com/sites/govuk-components/deploys)
 
@@ -144,12 +141,9 @@ gem install govuk-components
 
 ## Contributing
 
-Bug reports and feature requests are most welcome, please raise an issue or
-submit a pull request.
+Bug reports and feature requests are most welcome, please raise an issue or submit a pull request.
 
-Currently we're using [GOVUK Lint](https://github.com/alphagov/govuk-lint) to
-ensure code meets the GOV.UK guidelines. Please ensure that any PRs also adhere
-to this standard.
+Currently we're using [GOVUK Lint](https://github.com/alphagov/govuk-lint) to ensure code meets the GOV.UK guidelines. Please ensure that any PRs also adhere to this standard.
 
 To help keep the logs clean and tidy, please configure git to use your full name:
 

--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |spec|
   spec.authors     = ["DfE developers"]
   spec.email       = ["peter.yates@digital.education.gov.uk"]
   spec.homepage    = "https://github.com/x-govuk/govuk-components"
-  spec.summary     = "Lightweight set of reusable GOV.UK Design System components"
-  spec.description = "A collection of components intended to ease the building of GOV.UK Design System web applications"
+  spec.summary     = "GOV.UK Components for Ruby on Rails"
+  spec.description = "This library provides view components for the GOV.UK Design System. It makes creating services more familiar for Ruby on Rails developers."
   spec.license     = "MIT"
 
   spec.files = Dir["{app,config,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -3,7 +3,7 @@ title: Supported versions
 ---
 
 p.govuk-body
-  | GOV.UK components are actively maintained and support the
+  | GOV.UK Components are actively maintained and support the
     latest stable versions of the
     #{link_to('GOV.UK Design System',design_system_link).html_safe},
     #{link_to('Ruby on Rails', 'https://rubyonrails.org/').html_safe} and

--- a/guide/layouts/partials/head.slim
+++ b/guide/layouts/partials/head.slim
@@ -2,9 +2,9 @@ head
   meta charset="utf-8"
   title
     - if item[:title]
-      ' #{item[:title]} - GOV.UK Components
+      ' #{item[:title]} - GOV.UK Components for Ruby on Rails
     - else
-      ' GOV.UK Components
+      ' GOV.UK Components for Ruby on Rails
 
   meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"
   meta name="theme-color" content="#0b0c0c"

--- a/guide/layouts/partials/header.slim
+++ b/guide/layouts/partials/header.slim
@@ -14,4 +14,4 @@ header.govuk-header.app-header role="banner" data-module="govuk-header"
             | GOV.UK
 
         span.govuk-header__product-name<
-          | Ruby on Rails components
+          | Components for Ruby on Rails

--- a/guide/layouts/partials/masthead.slim
+++ b/guide/layouts/partials/masthead.slim
@@ -2,10 +2,10 @@
   .govuk-width-container
     .govuk-grid-row
       .govuk-grid-column-two-thirds-from-desktop
-        h1.app-masthead__title Build your GOV.UK service using Ruby on Rails components
+        h1.app-masthead__title Build GOV.UK services using Ruby on Rails components
 
         p.app-masthead__description
-          | This library provides view components for the GOV.UK Design System. It makes creating services easy and familiar for Ruby on Rails developers.
+          | This library provides view components for the GOV.UK Design System. It makes creating services more familiar for Ruby on Rails developers.
 
         a.govuk-button.govuk-button--start.app-button--inverse href="/introduction/get-started" role="button" draggable="false" data-module="govuk-button"
           | Get started

--- a/spec/dummy/app/views/demos/show.html.erb
+++ b/spec/dummy/app/views/demos/show.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">GOV.UK Rails Components</h1>
+    <h1 class="govuk-heading-xl">GOV.UK Components for Ruby on Rails</h1>
 
     <% Dir
         .glob(Rails.root.join('app', 'views', 'demos', 'examples', '*.html.erb'))

--- a/spec/dummy/app/views/home/index.html.erb
+++ b/spec/dummy/app/views/home/index.html.erb
@@ -1,1 +1,1 @@
-<h1 class="govuk-heading-xl">GOV.UK Components</h1>
+<h1 class="govuk-heading-xl">GOV.UK Components for Ruby on Rails</h1>

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="govuk-template">
   <head>
-    <title>GOV.UK Components</title>
+    <title>GOV.UK Components for Ruby on Rails</title>
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag    'application', media: 'all' %>
@@ -13,7 +13,7 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
     <%= govuk_skip_link %>
-    <%= govuk_header(crown: false, logotype: "GOV.UK Components") %>
+    <%= govuk_header(crown: false, logotype: "GOV.UK Components for Ruby on Rails") %>
     <%= yield :masthead %>
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content">


### PR DESCRIPTION
Long: ‘GOV.UK Components for Ruby on Rails’
Short: ‘GOV.UK Components’

See discussion in #430.