### PR TITLE
Upgrade to ViewComponent 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Test coverage](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/test_coverage)](https://codeclimate.com/github/x-govuk/govuk-components/test_coverage)
 [![Licence](https://img.shields.io/github/license/x-govuk/govuk-components)](https://github.com/x-govuk/govuk-components/blob/main/LICENSE.txt)
 [![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.6.0-brightgreen)](https://design-system.service.gov.uk)
+[![ViewComponent](https://img.shields.io/badge/ViewComponent-3.3.0-brightgreen)](https://viewcomponent.org/)
 [![Rails](https://img.shields.io/badge/Rails-6.1.7%20%E2%95%B1%207.0.3-E16D6D)](https://weblog.rubyonrails.org/releases/)
 [![Ruby](https://img.shields.io/badge/Ruby-3.0.5%20%20%E2%95%B1%203.1.3%20%20%E2%95%B1%203.2.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 

--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("html-attributes-utils", "~> 1.0.0", ">= 1.0.0")
   spec.add_dependency("pagy", "~> 6.0")
-  spec.add_dependency("view_component", "~> 3.0.0")
+  spec.add_dependency("view_component", "~> 3.3.0")
 
   spec.add_development_dependency "deep_merge"
   spec.add_development_dependency "pry-byebug"

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -1,3 +1,9 @@
+require 'rails'
+
+module FakeRails
+  class Application < Rails::Application; end
+end
+
 require 'pry'
 require 'action_view'
 require 'action_controller'


### PR DESCRIPTION
This [recent PR](https://github.com/ViewComponent/view_component/pull/1765) means that we need Rails to be set up in order to build the guide.