### PR TITLE
Change default pagination landmark to 'Pagination'

### DIFF
--- a/lib/govuk/components/engine.rb
+++ b/lib/govuk/components/engine.rb
@@ -46,7 +46,7 @@ module Govuk
     # +:default_footer_meta_text+ nil
     # +:default_footer_copyright_text+ '© Crown copyright'
     # +:default_footer_copyright_url+ "https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-    # +:default_pagination_landmark_label+ "results"
+    # +:default_pagination_landmark_label+ "Pagination"
     # +:default_pagination_next_text+ Default 'next' text for pagination. An +Array+ where the first item is visible and the second visually hidden. Defaults to ["Next", "page"]
     # +:default_pagination_previous_text+ Default 'previous' text for pagination. An +Array+ where the first item is visible and the second visually hidden. Defaults to ["Previous", "page"]
     # +:default_phase_banner_tag+ nil
@@ -80,7 +80,7 @@ module Govuk
       default_footer_meta_text: nil,
       default_footer_copyright_text: '© Crown copyright',
       default_footer_copyright_url: "https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/",
-      default_pagination_landmark_label: "results",
+      default_pagination_landmark_label: "Pagination",
       default_pagination_next_text: %w(Next page),
       default_pagination_previous_text: %w(Previous page),
       default_phase_banner_tag: nil,

--- a/spec/components/govuk_component/pagination_component_spec.rb
+++ b/spec/components/govuk_component/pagination_component_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe(GovukComponent::PaginationComponent, type: :component) do
     expect(rendered_content).not_to have_tag("nav", with: { class: %w(govuk-pagination--block) })
   end
 
-  specify "renders a default landmark label of 'results'" do
-    expect(rendered_content).to have_tag("nav", with: { "aria-label" => "results" })
+  specify "renders a default landmark label of 'Pagination'" do
+    expect(rendered_content).to have_tag("nav", with: { "aria-label" => "Pagination" })
   end
 
   specify "renders a previous link" do


### PR DESCRIPTION
After an accessibility audit it was decided that 'results' [isn't specific or descriptive enough](https://github.com/alphagov/govuk-frontend/pull/3899).

This being merged is pending on the upstream PR being accepted.