### PR TITLE
Add example of summary list with missing info

### DIFF
--- a/guide/content/components/summary-list.slim
+++ b/guide/content/components/summary-list.slim
@@ -39,6 +39,13 @@ p
     consuming the remaining space.
 
 == render('/partials/example.*',
+  caption: "Summary lists with missing information",
+  code: summary_list_with_missing_information) do
+
+  markdown:
+    If a row has missing information, include a link to add the information within the value column instead of as an action.
+
+== render('/partials/example.*',
   caption: "Building a summary list directly from data",
   code: summary_list_from_rows,
   data: summary_list_from_rows_data) do

--- a/guide/lib/examples/summary_list_helpers.rb
+++ b/guide/lib/examples/summary_list_helpers.rb
@@ -43,6 +43,25 @@ module Examples
       SUMMARY_LIST_WITHOUT_ACTIONS
     end
 
+    def summary_list_with_missing_information
+      <<~SUMMARY_LIST_WITH_MISSING_INFORMATION
+        = govuk_summary_list do |summary_list|
+          - summary_list.with_row do |row|
+            - row.with_key { 'Name' }
+            - row.with_value { 'Sherlock Holmes' }
+            - row.with_action(text: "Change", href: '#', visually_hidden_text: 'name')
+
+          - summary_list.with_row do |row|
+            - row.with_key(text: 'Address')
+            - row.with_value { govuk_link_to("Enter address", "#") }
+
+          - summary_list.with_row do |row|
+            - row.with_key(text: 'Phone number')
+            - row.with_value(text: '020 123 1234')
+            - row.with_action(text: "Change", href: '#', visually_hidden_text: 'phone number')
+      SUMMARY_LIST_WITH_MISSING_INFORMATION
+    end
+
     def summary_list_from_rows
       <<~SUMMARY_LIST_FROM_ROWS
         = govuk_summary_list(rows: rows)


### PR DESCRIPTION
This shows how to code the pattern for [showing missing information within the summary list](https://design-system.service.gov.uk/components/summary-list/#showing-missing-information).