### PR TITLE
Update govuk_button_to

### DIFF
--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -43,7 +43,16 @@ module GovukLinkHelper
 
   def govuk_button_to(name = nil, options = nil, extra_options = {}, &block)
     extra_options = options if block_given?
-    html_options = build_html_options(extra_options, style: :button)
+    html_options = {
+      data: {module: "govuk-button"}
+    }
+
+    if extra_options && extra_options[:prevent_double_click]
+      html_options[:data]["prevent-double-click"] = "true"
+      extra_options = extra_options.except(:prevent_double_click)
+    end
+
+    html_options.merge! build_html_options(extra_options, style: :button)
 
     if block_given?
       button_to(options, html_options, &block)

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -1,11 +1,12 @@
 require 'rails'
+require 'action_view'
+ActionView::Helpers::UrlHelper.button_to_generates_button_tag = true
 
 module FakeRails
   class Application < Rails::Application; end
 end
 
 require 'pry'
-require 'action_view'
 require 'action_controller'
 require 'htmlbeautifier'
 require 'slim/erb_converter'

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -11,7 +11,7 @@ require "govuk/components"
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 7.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       specify "renders a form with a button and the correct attributes" do
         expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
-          with_tag("button", with: { class: "govuk-button", "data-module": "govuk-button" })
+          with_tag("button", with: { class: "govuk-button", "data-module": "govuk-button" }, text: button_text)
         end
       end
     end
@@ -181,7 +181,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       specify "renders a form with a button and the correct attributes" do
         expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
-          with_tag("button", with: { class: "govuk-button", "data-module": "govuk-button", "data-prevent-double-click": "true" })
+          with_tag("button", with: { class: "govuk-button", "data-module": "govuk-button", "data-prevent-double-click": "true" }, text: button_text)
         end
       end
     end
@@ -193,7 +193,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       specify "renders a form with a button and the correct attributes" do
         expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
-          with_tag("button", with: { class: "govuk-button", "data-module": "govuk-button" })
+          with_tag("button", with: { class: "govuk-button", "data-module": "govuk-button" }, text: button_text)
         end
       end
     end
@@ -205,7 +205,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       specify "renders a form with a button that has the GOV.UK modifier classes" do
         expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
-          with_tag("button", with: { class: %w(govuk-button govuk-button--secondary), "data-module": "govuk-button" })
+          with_tag("button", with: { class: %w(govuk-button govuk-button--secondary), "data-module": "govuk-button" }, text: button_text)
         end
       end
     end
@@ -215,7 +215,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       specify "renders a form with an button that has the custom classes" do
         expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
-          with_tag("button", with: { type: "submit", class: %w(govuk-button yellow govuk-button--disabled), "data-module": "govuk-button" })
+          with_tag("button", with: { type: "submit", class: %w(govuk-button yellow govuk-button--disabled), "data-module": "govuk-button" }, text: button_text)
         end
       end
     end

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -169,9 +169,19 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     context "when provided with button text and url params" do
       subject { govuk_button_to(button_text, button_params) }
 
-      specify "renders a form with an input of type submit and the correct attributes" do
+      specify "renders a form with a button and the correct attributes" do
         expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
-          with_tag("input", with: { type: "submit", class: "govuk-button" })
+          with_tag("button", with: { class: "govuk-button", "data-module": "govuk-button" })
+        end
+      end
+    end
+
+    context "when provided with button text, a path and preventing double click" do
+      subject { govuk_button_to(button_text, "/", prevent_double_click: true) }
+
+      specify "renders a form with a button and the correct attributes" do
+        expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
+          with_tag("button", with: { class: "govuk-button", "data-module": "govuk-button", "data-prevent-double-click": "true" })
         end
       end
     end
@@ -181,9 +191,9 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       subject { govuk_button_to(button_params) { button_html } }
 
-      specify "renders a form with an button of type submit and the correct attributes" do
+      specify "renders a form with a button and the correct attributes" do
         expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
-          with_tag("button", with: { class: "govuk-button" })
+          with_tag("button", with: { class: "govuk-button", "data-module": "govuk-button" })
         end
       end
     end
@@ -193,9 +203,9 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       subject { govuk_button_to(button_text, button_params, custom_button_options) }
 
-      specify "renders a form with an button that has the GOV.UK modifier classes" do
+      specify "renders a form with a button that has the GOV.UK modifier classes" do
         expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
-          with_tag("input", with: { type: "submit", class: %w(govuk-button govuk-button--secondary) })
+          with_tag("button", with: { class: %w(govuk-button govuk-button--secondary), "data-module": "govuk-button" })
         end
       end
     end
@@ -205,7 +215,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       specify "renders a form with an button that has the custom classes" do
         expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
-          with_tag("input", with: { type: "submit", class: %w(govuk-button yellow govuk-button--disabled) })
+          with_tag("button", with: { type: "submit", class: %w(govuk-button yellow govuk-button--disabled), "data-module": "govuk-button" })
         end
       end
     end


### PR DESCRIPTION
This updates the behaviour of the `govuk_button_to` helper, so that:

* it adds the `data-module="govuk-button"` attribute to the button
* it always outputs a `<button>` element instead of `<input type="submit">` (this is now default behaviour in Rails 7)
* if `prevent_double_click: true` is set, `data-prevent-double-click="true"` is added to allow double click prevention (in common with the [`govuk_submit` helper on the formbuilder](https://govuk-form-builder.netlify.app/form-elements/submit))