### PR TITLE
Add app dir to ruby-lint task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ check: ruby-lint slim-lint rspec nanoc-check
 nanoc-check: nanoc-check-all
 
 ruby-lint:
-	${prefix} rubocop lib spec guide/lib
+	${prefix} rubocop app lib spec guide/lib
 slim-lint:
 	${prefix} slim-lint guide
 rspec:


### PR DESCRIPTION
The task was written before this library used app and never updated 🤦
