### PR TITLE
Update Accordion Section with role for aria

### DIFF
--- a/app/components/govuk_component/accordion_component/section_component.html.erb
+++ b/app/components/govuk_component/accordion_component/section_component.html.erb
@@ -7,5 +7,5 @@
       <%= tag.div(summary_content, id: id(suffix: 'summary'), class: "#{brand}-accordion__section-summary #{brand}-body") %>
     <% end %>
   </div>
-  <%= tag.div(content, id: id(suffix: 'content'), class: "#{brand}-accordion__section-content", aria: { labelledby: id }) %>
+  <%= tag.div(content, id: id(suffix: 'content'), role: 'region', class: "#{brand}-accordion__section-content", aria: { labelledby: id }) %>
 <% end %>


### PR DESCRIPTION
When the axe-* gems update to 4.8.0, our automated tests started to fail with a `aria-labelledby attribute cannot be used on a div with no valid role attribute` error.

Adding a role tag to this section allows the tests to pass...

but I am not sure if the `region` role is the most appropriate