### PR TITLE
Set supported Rails versions to 7.0.8 and 7.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install gems
         env:
-          RAILS_VERSION: '6.1.7.4'
+          RAILS_VERSION: '7.0.8'
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.0.6', '3.1.4', '3.2.2']
-        rails: ['6.1.7', '7.0.6']
+        rails: ['7.0.8', '7.1.0']
     runs-on: ubuntu-20.04
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     steps:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Licence](https://img.shields.io/github/license/x-govuk/govuk-components)](https://github.com/x-govuk/govuk-components/blob/main/LICENSE.txt)
 [![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.7.0-brightgreen)](https://design-system.service.gov.uk)
 [![ViewComponent](https://img.shields.io/badge/ViewComponent-3.3.0-brightgreen)](https://viewcomponent.org/)
-[![Rails](https://img.shields.io/badge/Rails-6.1.7%20%E2%95%B1%207.0.6-E16D6D)](https://weblog.rubyonrails.org/releases/)
+[![Rails](https://img.shields.io/badge/Rails-7.0.8%20%E2%95%B1%207.1.0-E16D6D)](https://weblog.rubyonrails.org/releases/)
 [![Ruby](https://img.shields.io/badge/Ruby-3.0.6%20%20%E2%95%B1%203.1.4%20%20%E2%95%B1%203.2.2-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 
 This gem provides a suite of reusable components for the [GOV.UK Design System](https://design-system.service.gov.uk/). It is intended to provide a lightweight alternative to the [GOV.UK Publishing Components](https://github.com/alphagov/govuk_publishing_components) library and is built with GitHub’s [ViewComponent](https://github.com/github/view_component) framework.

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -30,9 +30,9 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | Ruby on Rails
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 7.0.6
+        | 7.1.0
         br
-        | 6.1.7
+        | 7.0.8
       td.govuk-table__cell.govuk-table__cell--numeric
         | 6.1.4.4
         br


### PR DESCRIPTION
This maintains the usual flow of supporting the most recent two major versions
