### PR TITLE
Refactor `phase_tag_component` to fix failing spec

### DIFF
--- a/app/components/govuk_component/phase_banner_component.rb
+++ b/app/components/govuk_component/phase_banner_component.rb
@@ -14,7 +14,7 @@ class GovukComponent::PhaseBannerComponent < GovukComponent::Base
   end
 
   def phase_tag_component
-    GovukComponent::TagComponent.new(**phase_tag.deep_merge(classes: "#{brand}-phase-banner__content__tag"))
+    GovukComponent::TagComponent.new(**phase_tag, classes: "#{brand}-phase-banner__content__tag")
   end
 
 private


### PR DESCRIPTION
There's an unnecessary #deep_merge here that somehow seems to confuse the tests, the outer hash sees the overridden #brand but the inner one doesn't and reverts to "govuk", causing the 'ensure everything's overridden' test to fail.

I don't think this would cause any problems in a live environment where the brand value is set once during initialisation and left.
