### PR TITLE
Add spec ensuring viewBox is properly capitalised

### DIFF
--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
     expect(rendered_content).to have_tag('footer', with: { class: component_css_class }) do
       with_tag("div", with: { class: "govuk-footer__meta" }) do
         with_tag("svg", with: { class: "govuk-footer__licence-logo", 'aria-hidden' => true })
+        expect(html).to contain_svgs_with_viewBox_attributes
       end
     end
   end

--- a/spec/components/govuk_component/header_component_spec.rb
+++ b/spec/components/govuk_component/header_component_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
       specify 'the crown SVG is rendered along with no fallback image' do
         expect(rendered_content).to have_tag('.govuk-header__logotype') do
           with_tag('svg', with: { class: 'govuk-header__logotype-crown', 'aria-hidden' => true })
+          expect(html).to contain_svgs_with_viewBox_attributes
         end
       end
 

--- a/spec/components/govuk_component/pagination_component_spec.rb
+++ b/spec/components/govuk_component/pagination_component_spec.rb
@@ -304,6 +304,8 @@ RSpec.describe(GovukComponent::PaginationComponent, type: :component) do
       expect(rendered_content).to have_tag("nav") do
         with_tag("div", class: "govuk-pagination__prev")
         with_tag("div", class: "govuk-pagination__next")
+
+        expect(html).to contain_svgs_with_viewBox_attributes
       end
     end
 
@@ -326,6 +328,7 @@ RSpec.describe(GovukComponent::PaginationComponent, type: :component) do
         specify "has an arrow" do
           expect(rendered_content).to have_tag(selector) do
             with_tag("svg", with: { class: ["govuk-pagination__icon", "govuk-pagination__icon--#{page.suffix}"] })
+            expect(html).to contain_svgs_with_viewBox_attributes
           end
         end
 

--- a/spec/components/govuk_component/start_button_component_spec.rb
+++ b/spec/components/govuk_component/start_button_component_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe(GovukComponent::StartButtonComponent, type: :component) do
     specify 'the link contains an SVG chevron' do
       expect(rendered_content).to have_tag('a') do
         with_tag('svg', with: { 'aria-hidden' => true }) { with_tag('path') }
+        expect(html).to contain_svgs_with_viewBox_attributes
       end
     end
 

--- a/spec/components/shared/custom_matchers.rb
+++ b/spec/components/shared/custom_matchers.rb
@@ -1,0 +1,14 @@
+RSpec.configure do
+  RSpec::Matchers.define(:contain_svgs_with_viewBox_attributes) do
+    match do |element|
+      all_svgs = element.search("//xmlns:svg", "xmlns" => "http://www.w3.org/2000/svg")
+      svgs_with_viewbox = element.search("//xmlns:svg[@viewBox]", "xmlns" => "http://www.w3.org/2000/svg")
+
+      expect(all_svgs).to match_array(svgs_with_viewbox)
+    end
+
+    failure_message do |element|
+      "expected #{element} to contain <svg> element with a viewBox attribute"
+    end
+  end
+end


### PR DESCRIPTION
XML (and therefore SVG) is case sensitive and viewBox is the correct attribute name, based on @aliuk2012's suggestion.

Refs #459, #461
