### PR TITLE
Fix module name in include

### DIFF
--- a/app/helpers/govuk_visually_hidden_helper.rb
+++ b/app/helpers/govuk_visually_hidden_helper.rb
@@ -10,4 +10,4 @@ module GovukVisuallyHiddenHelper
   end
 end
 
-ActiveSupport.on_load(:action_view) { include GovukSkipLinkHelper }
+ActiveSupport.on_load(:action_view) { include GovukVisuallyHiddenHelper }


### PR DESCRIPTION
Fixes #470

Guess this is hard to test for, as the tests include the module directly rather than loading ActionView.