### PR TITLE
Drop focusable option from govuk_visually_hidden

### DIFF
--- a/app/helpers/govuk_visually_hidden_helper.rb
+++ b/app/helpers/govuk_visually_hidden_helper.rb
@@ -1,12 +1,8 @@
 module GovukVisuallyHiddenHelper
   def govuk_visually_hidden(text = nil, focusable: false, &block)
-    content = (block_given?) ? block.call : text
+    return if text.blank? && block.nil?
 
-    return if content.blank?
-
-    visually_hidden_class = focusable ? "govuk-visually-hidden-focusable" : "govuk-visually-hidden"
-
-    tag.span(content, class: visually_hidden_class)
+    tag.span(text, class: "govuk-visually-hidden", &block)
   end
 end
 

--- a/app/helpers/govuk_visually_hidden_helper.rb
+++ b/app/helpers/govuk_visually_hidden_helper.rb
@@ -1,5 +1,5 @@
 module GovukVisuallyHiddenHelper
-  def govuk_visually_hidden(text = nil, focusable: false, &block)
+  def govuk_visually_hidden(text = nil, &block)
     return if text.blank? && block.nil?
 
     tag.span(text, class: "govuk-visually-hidden", &block)

--- a/guide/content/helpers/visually-hidden-text.slim
+++ b/guide/content/helpers/visually-hidden-text.slim
@@ -3,8 +3,8 @@ title: Visually hidden text
 ---
 
 markdown:
-  Most of the time content should be both visible on the screen and availble to
-  screen readers. However, somtimes when space is at a premium, we may want
+  Most of the time content should be both visible on the screen and available to
+  screen readers. However, sometimes when space is at a premium, we may want
   to hide text that would clutter the screen. This puts users of assistive
   technology like screen readers at a disadvantage.
 
@@ -19,7 +19,3 @@ markdown:
 == render('/partials/example.*',
   caption: "Setting visually hidden text with a block",
   code: visually_hidden_text_via_block)
-
-== render('/partials/example.*',
-  caption: "Focusable visually hidden text",
-  code: focusable_visually_hidden_text)

--- a/guide/lib/examples/visually_hidden_helpers.rb
+++ b/guide/lib/examples/visually_hidden_helpers.rb
@@ -20,18 +20,5 @@ module Examples
         p More regular text
       SNIPPET
     end
-
-    def focusable_visually_hidden_text
-      <<~SNIPPET
-        p Regular text
-
-        p
-          a href="#"
-            | Some link
-            = govuk_visually_hidden("Focus on me", focusable: true)
-
-        p More regular text
-      SNIPPET
-    end
   end
 end

--- a/spec/helpers/govuk_visually_hidden_helper_spec.rb
+++ b/spec/helpers/govuk_visually_hidden_helper_spec.rb
@@ -15,5 +15,11 @@ RSpec.describe(GovukVisuallyHiddenHelper, type: 'helper') do
 
       it { is_expected.to have_tag('span', with: { class: "govuk-visually-hidden" }, text: "first item") }
     end
+
+    context 'when text is provided as a block' do
+      subject { govuk_visually_hidden { "first item" } }
+
+      it { is_expected.to have_tag('span', with: { class: "govuk-visually-hidden" }, text: "first item") }
+    end
   end
 end


### PR DESCRIPTION
Turns out this should only be applied directly to focusable elements like links and buttons.

Also added a test for the block syntax option, and refactored a bit.