### PR TITLE
Add summary card visually hidden text

### DIFF
--- a/app/components/govuk_component/summary_list_component.rb
+++ b/app/components/govuk_component/summary_list_component.rb
@@ -55,7 +55,7 @@ module GovukComponent
         with_row(**data.slice(:classes, :html_attributes)) do |r|
           r.with_key(**k)
           r.with_value(**v)
-          Array.wrap(a).each { |ad| r.with_action(**ad) }
+          Array.wrap(a).each { |ad| r.with_action(card_title: card&.title, **ad) }
         end
       end
     end

--- a/app/components/govuk_component/summary_list_component/action_component.rb
+++ b/app/components/govuk_component/summary_list_component/action_component.rb
@@ -1,7 +1,7 @@
 class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Base
-  attr_reader :href, :text, :visually_hidden_text, :attributes, :classes
+  attr_reader :href, :text, :visually_hidden_text, :attributes, :classes, :card_title
 
-  def initialize(href: nil, text: 'Change', visually_hidden_text: false, classes: [], html_attributes: {})
+  def initialize(href: nil, text: 'Change', visually_hidden_text: false, classes: [], html_attributes: {}, card_title: nil)
     @visually_hidden_text = visually_hidden_text
 
     if config.require_summary_list_action_visually_hidden_text && visually_hidden_text == false
@@ -12,6 +12,7 @@ class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Ba
 
     @href = href
     @text = text
+    @card_title = card_title
   end
 
   def render?
@@ -37,6 +38,10 @@ private
   end
 
   def visually_hidden_span
-    tag.span(%( #{visually_hidden_text}), class: "#{brand}-visually-hidden") if visually_hidden_text.present?
+    if visually_hidden_text.present? || card_title.present?
+      tag.span(%( #{visually_hidden_text}), class: "#{brand}-visually-hidden") do
+        " " + visually_hidden_text + (card_title.present? ? " (" + card_title + ")" : "")
+      end
+    end
   end
 end


### PR DESCRIPTION
I think this works, but it only works if you use the helper syntax with all the arguments:

```erb
<%= govuk_summary_list(card: { title: "Card title" }, rows: [...]) %>
```

and not the slot syntax:

```erb
<%= govuk_summary_card(title: "Card title") do |card| %>
  card.with_summary_list(rows: [...])
end %>
```

There’s no tests for it yet, as the existing tests use the slot syntax.

See #479