### PR TITLE
Fix source map loading in the guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ guide/*.log
 guide/node_modules
 guide/content/assets/images
 guide/content/javascripts/*.js
+guide/content/javascripts/*.map

--- a/guide/package.json
+++ b/guide/package.json
@@ -7,7 +7,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "postinstall": "cp -R node_modules/govuk-frontend/dist/govuk/assets/images content/assets && cp node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js content/javascripts/govuk-frontend.min.js",
+    "postinstall": "cp -R node_modules/govuk-frontend/dist/govuk/assets/images content/assets && cp node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js content/javascripts/govuk-frontend.min.js && cp node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js.map content/javascripts/govuk-frontend.min.js.map",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",


### PR DESCRIPTION
The source map location is hardcoded in the minified JavaScript so we just need to copy the .map file to the right spot.
