### PR TITLE
Add `cannot_start_yet` argument to the task list status component

### DIFF
--- a/app/components/govuk_component/task_list_component/item_component.rb
+++ b/app/components/govuk_component/task_list_component/item_component.rb
@@ -40,6 +40,10 @@ module GovukComponent
     end
 
     def call
+      if href.presence && status_content.cannot_start_yet
+        fail(ArgumentError, "item cannot have a href with status where cannot_start_yet: true")
+      end
+
       adjusted_html_attributes = if href.present? || title&.href.present?
                                    html_attributes_with_link_class
                                  else

--- a/app/components/govuk_component/task_list_component/item_component.rb
+++ b/app/components/govuk_component/task_list_component/item_component.rb
@@ -1,10 +1,11 @@
 module GovukComponent
   class TaskListComponent::ItemComponent < GovukComponent::Base
-    renders_one :status, ->(text: nil, classes: [], html_attributes: {}, &block) do
+    renders_one :status, ->(text: nil, cannot_start_yet: false, classes: [], html_attributes: {}, &block) do
       GovukComponent::TaskListComponent::StatusComponent.new(
         id_prefix: @id_prefix,
         count: @count,
         text: text,
+        cannot_start_yet: cannot_start_yet,
         classes: classes,
         html_attributes: html_attributes,
         &block

--- a/app/components/govuk_component/task_list_component/status_component.rb
+++ b/app/components/govuk_component/task_list_component/status_component.rb
@@ -1,11 +1,12 @@
 module GovukComponent
   class TaskListComponent::StatusComponent < GovukComponent::Base
-    attr_reader :id_prefix, :text, :count
+    attr_reader :id_prefix, :text, :cannot_start_yet, :count
 
-    def initialize(text: nil, id_prefix: nil, count: nil, classes: [], html_attributes: {})
-      @text      = text
-      @count     = count
-      @id_prefix = id_prefix
+    def initialize(text: nil, id_prefix: nil, count: nil, cannot_start_yet: false, classes: [], html_attributes: {})
+      @text             = text
+      @count            = count
+      @id_prefix        = id_prefix
+      @cannot_start_yet = cannot_start_yet
 
       super(classes: classes, html_attributes: html_attributes)
     end
@@ -21,7 +22,13 @@ module GovukComponent
   private
 
     def default_attributes
-      { class: %w(govuk-task-list__status), id: [id_prefix, count, "status"].compact.join("-") }
+      {
+        class: class_names(
+          "govuk-task-list__status",
+          "govuk-task-list__status--cannot-start-yet" => cannot_start_yet,
+        ),
+        id: [id_prefix, count, "status"].compact.join("-"),
+      }
     end
 
     def status_text

--- a/guide/content/components/task-list.slim
+++ b/guide/content/components/task-list.slim
@@ -35,7 +35,7 @@ markdown:
   code: task_list_with_cannot_start_yet) do
 
   markdown:
-    Tasks can omit the `href` keyword if they cannot be started yet. When doing this you should add the `govuk-task-list__status--cannot-start-yet` to the status, and a hint to explain why the task cannot be started yet.
+    Tasks can omit the `href` keyword if they cannot be started yet. When doing this you should add `cannot_start_yet: true` to the status, and a hint to explain why the task cannot be started yet.
 
 == render('/partials/example.*',
   caption: "Task list with custom classes",

--- a/guide/lib/examples/task_list_helpers.rb
+++ b/guide/lib/examples/task_list_helpers.rb
@@ -20,7 +20,7 @@ module Examples
           - task_list.with_item(title: "Contact details", href: '#', status: "Completed")
           - task_list.with_item(title: "Project details", href: '#', status: "Completed")
           - task_list.with_item(title: "Funding", hint: "The funds will be announced on 1 April 2022") do |item|
-            - item.with_status(text: "Cannot start yet", classes: "govuk-task-list__status--cannot-start-yet")
+            - item.with_status(text: "Cannot start yet", cannot_start_yet: true)
       SNIPPET
     end
 

--- a/spec/components/govuk_component/task_list_component_spec.rb
+++ b/spec/components/govuk_component/task_list_component_spec.rb
@@ -130,6 +130,44 @@ RSpec.describe(GovukComponent::TaskListComponent, type: :component) do
     end
   end
 
+  describe "status cannot_start_yet" do
+    let(:title_text) { "Choose a course" }
+    let(:hint_text) { "Determine eligibility" }
+    let(:status_text) { "Not done" }
+    let(:cannot_start_yet) { false }
+
+    subject! do
+      render_inline(GovukComponent::TaskListComponent.new(**kwargs)) do |task_list|
+        task_list.with_item do |item|
+          helper.safe_join(
+            [
+              item.with_title(text: title_text, hint: hint_text),
+              item.with_status(text: status_text, cannot_start_yet: cannot_start_yet),
+            ]
+          )
+        end
+      end
+    end
+
+    context "when false (default)" do
+      specify "there is no govuk-task-list__status--cannot-start-yet class" do
+        expect(rendered_content).not_to have_tag(".govuk-task-list__status--cannot-start-yet")
+      end
+    end
+
+    context "when true" do
+      let(:cannot_start_yet) { true }
+
+      specify "the status has an extra class marking that it cannot yet be started" do
+        expect(rendered_content).to have_tag(
+          "div",
+          with: { class: %w(govuk-task-list__status govuk-task-list__status--cannot-start-yet) },
+          text: status_text,
+        )
+      end
+    end
+  end
+
   describe "status presence" do
     let(:status_class) { "govuk-task-list__status" }
 

--- a/spec/components/govuk_component/task_list_component_spec.rb
+++ b/spec/components/govuk_component/task_list_component_spec.rb
@@ -92,6 +92,30 @@ RSpec.describe(GovukComponent::TaskListComponent, type: :component) do
           end
         end
       end
+
+      context "when items have an element that cannot start yet" do
+        let(:list_item_two_kwargs) { { title: "Two", status: { text: "todo", cannot_start_yet: true } } }
+
+        specify "the status has an extra class marking that it cannot yet be started" do
+          expect(rendered_content).to have_tag(
+            "div",
+            with: { class: %w(govuk-task-list__status govuk-task-list__status--cannot-start-yet) },
+            text: "todo",
+          )
+        end
+      end
+
+      context "when an item has an element that cannot start yet and a href" do
+        let(:failing_component) do
+          render_inline(GovukComponent::TaskListComponent.new(**kwargs)) do |task_list|
+            task_list.with_item(title: "Two", href: "#", status: { text: "todo", cannot_start_yet: true })
+          end
+        end
+
+        specify "the component raises an error because an item has both a href and cannot_start_yet: true" do
+          expect { failing_component }.to raise_error(ArgumentError, /item cannot have a href with status where cannot_start_yet: true/)
+        end
+      end
     end
 
     describe "when rendered with blocks" do
@@ -135,10 +159,11 @@ RSpec.describe(GovukComponent::TaskListComponent, type: :component) do
     let(:hint_text) { "Determine eligibility" }
     let(:status_text) { "Not done" }
     let(:cannot_start_yet) { false }
+    let(:item_kwargs) { {} }
 
     subject! do
       render_inline(GovukComponent::TaskListComponent.new(**kwargs)) do |task_list|
-        task_list.with_item do |item|
+        task_list.with_item(**item_kwargs) do |item|
           helper.safe_join(
             [
               item.with_title(text: title_text, hint: hint_text),
@@ -164,6 +189,25 @@ RSpec.describe(GovukComponent::TaskListComponent, type: :component) do
           with: { class: %w(govuk-task-list__status govuk-task-list__status--cannot-start-yet) },
           text: status_text,
         )
+      end
+    end
+
+    context "when an item has an element that cannot start yet and a href" do
+      let(:failing_component) do
+        render_inline(GovukComponent::TaskListComponent.new(**kwargs)) do |task_list|
+          task_list.with_item(href: "https://www.gov.uk") do |item|
+            helper.safe_join(
+              [
+                item.with_title(text: title_text, hint: hint_text),
+                item.with_status(text: status_text, cannot_start_yet: true),
+              ]
+            )
+          end
+        end
+      end
+
+      specify "the component raises an error because an item has both a href and cannot_start_yet: true" do
+        expect { failing_component }.to raise_error(ArgumentError, /item cannot have a href with status where cannot_start_yet: true/)
       end
     end
   end


### PR DESCRIPTION
It provides a nicer way to add the class `govuk-task-list__status--cannot-start-yet` than manually providing it.
