### PR TITLE
Add support for Ruby 3.3, drop support for Ruby 3.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0.6'
+          ruby-version: '3.1.4'
 
       - name: Install gems
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0.6', '3.1.4', '3.2.2']
+        ruby: ['3.1.4', '3.2.2', '3.3.0']
         rails: ['7.0.8', '7.1.0']
     runs-on: ubuntu-20.04
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_gem:
     - config/rails.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   Exclude:
     - govuk_design_system_formbuilder.gemspec
     - spec/dummy/**/*

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-5.0.0-brightgreen)](https://design-system.service.gov.uk)
 [![ViewComponent](https://img.shields.io/badge/ViewComponent-3.3.0-brightgreen)](https://viewcomponent.org/)
 [![Rails](https://img.shields.io/badge/Rails-7.0.8%20%E2%95%B1%207.1.0-E16D6D)](https://weblog.rubyonrails.org/releases/)
-[![Ruby](https://img.shields.io/badge/Ruby-3.0.6%20%20%E2%95%B1%203.1.4%20%20%E2%95%B1%203.2.2-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Ruby](https://img.shields.io/badge/Ruby-3.1.4%20%20%E2%95%B1%203.2.2%20%20%E2%95%B1%203.3.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 
 This gem provides a suite of reusable components for the [GOV.UK Design System](https://design-system.service.gov.uk/). It is intended to provide a lightweight alternative to the [GOV.UK Publishing Components](https://github.com/alphagov/govuk_publishing_components) library and is built with GitHub’s [ViewComponent](https://github.com/github/view_component) framework.
 

--- a/app/components/govuk_component/accordion_component.rb
+++ b/app/components/govuk_component/accordion_component.rb
@@ -1,13 +1,13 @@
 class GovukComponent::AccordionComponent < GovukComponent::Base
   renders_many :sections, ->(heading_text: nil, summary_text: nil, expanded: false, classes: [], html_attributes: {}, &block) do
     GovukComponent::AccordionComponent::SectionComponent.new(
-      classes: classes,
-      expanded: expanded,
-      heading_level: heading_level, # set once at parent level, passed to all children
-      html_attributes: html_attributes,
-      summary_text: summary_text,
-      heading_text: heading_text,
-      accordion_id: accordion_id,
+      classes:,
+      expanded:,
+      heading_level:, # set once at parent level, passed to all children
+      html_attributes:,
+      summary_text:,
+      heading_text:,
+      accordion_id:,
       &block
     )
   end
@@ -18,7 +18,7 @@ class GovukComponent::AccordionComponent < GovukComponent::Base
     @heading_level = heading_tag(heading_level)
     @accordion_id  = html_attributes[:id]
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
 private

--- a/app/components/govuk_component/accordion_component/section_component.rb
+++ b/app/components/govuk_component/accordion_component/section_component.rb
@@ -13,7 +13,7 @@ class GovukComponent::AccordionComponent::SectionComponent < GovukComponent::Bas
     @heading_level = heading_level
     @accordion_id  = accordion_id
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def id(suffix: nil)

--- a/app/components/govuk_component/back_link_component.rb
+++ b/app/components/govuk_component/back_link_component.rb
@@ -6,7 +6,7 @@ class GovukComponent::BackLinkComponent < GovukComponent::Base
     @href = href
     @inverse = inverse
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call

--- a/app/components/govuk_component/breadcrumbs_component.rb
+++ b/app/components/govuk_component/breadcrumbs_component.rb
@@ -13,7 +13,7 @@ class GovukComponent::BreadcrumbsComponent < GovukComponent::Base
     @collapse_on_mobile = collapse_on_mobile
     @inverse            = inverse
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
 private

--- a/app/components/govuk_component/cookie_banner_component.rb
+++ b/app/components/govuk_component/cookie_banner_component.rb
@@ -15,11 +15,11 @@ module GovukComponent
       @hidden        = hidden
       @hide_in_print = hide_in_print
 
-      super(classes: classes, html_attributes: html_attributes)
+      super(classes:, html_attributes:)
     end
 
     def call
-      tag.div(role: "region", aria: { label: aria_label }, data: { nosnippet: true }, hidden: hidden, **html_attributes) do
+      tag.div(role: "region", aria: { label: aria_label }, data: { nosnippet: true }, hidden:, **html_attributes) do
         safe_join(messages)
       end
     end

--- a/app/components/govuk_component/cookie_banner_component/message_component.rb
+++ b/app/components/govuk_component/cookie_banner_component/message_component.rb
@@ -10,11 +10,11 @@ class GovukComponent::CookieBannerComponent::MessageComponent < GovukComponent::
     @hidden       = hidden
     @role         = role
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call
-    tag.div(role: role, hidden: hidden, **html_attributes) do
+    tag.div(role:, hidden:, **html_attributes) do
       safe_join([
         tag.div(class: "#{brand}-grid-row") do
           tag.div(class: "#{brand}-grid-column-two-thirds") { safe_join([heading_element, message_element]) }

--- a/app/components/govuk_component/details_component.rb
+++ b/app/components/govuk_component/details_component.rb
@@ -9,11 +9,11 @@ class GovukComponent::DetailsComponent < GovukComponent::Base
     @id           = id
     @open         = open
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call
-    tag.details(id: id, open: open, **html_attributes) do
+    tag.details(id:, open:, **html_attributes) do
       safe_join([summary, description])
     end
   end

--- a/app/components/govuk_component/exit_this_page_component.rb
+++ b/app/components/govuk_component/exit_this_page_component.rb
@@ -21,7 +21,7 @@ class GovukComponent::ExitThisPageComponent < GovukComponent::Base
     @press_two_more_times_text = press_two_more_times_text
     @press_one_more_time_text = press_one_more_time_text
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call

--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -31,7 +31,7 @@ class GovukComponent::FooterComponent < GovukComponent::Base
     @custom_container_classes         = container_classes
     @custom_container_html_attributes = container_html_attributes
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
 private

--- a/app/components/govuk_component/header_component.rb
+++ b/app/components/govuk_component/header_component.rb
@@ -29,7 +29,7 @@ class GovukComponent::HeaderComponent < GovukComponent::Base
     @navigation_label          = navigation_label
     @custom_container_classes  = container_classes
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
 private
@@ -57,7 +57,7 @@ private
       @options         = options
       @active_override = active
 
-      super(classes: classes, html_attributes: html_attributes)
+      super(classes:, html_attributes:)
     end
 
     def before_render
@@ -104,7 +104,7 @@ private
     def initialize(name: nil, html_attributes: {}, classes: [])
       @name = name
 
-      super(classes: classes, html_attributes: html_attributes)
+      super(classes:, html_attributes:)
     end
 
     def render?

--- a/app/components/govuk_component/inset_text_component.rb
+++ b/app/components/govuk_component/inset_text_component.rb
@@ -5,11 +5,11 @@ class GovukComponent::InsetTextComponent < GovukComponent::Base
     @text = text
     @id   = id
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call
-    tag.div(id: id, **html_attributes) { inset_text_content }
+    tag.div(id:, **html_attributes) { inset_text_content }
   end
 
   def render?

--- a/app/components/govuk_component/notification_banner_component.rb
+++ b/app/components/govuk_component/notification_banner_component.rb
@@ -23,7 +23,7 @@ class GovukComponent::NotificationBannerComponent < GovukComponent::Base
     @title_heading_level = title_heading_level
     @disable_auto_focus  = disable_auto_focus
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def render?
@@ -38,7 +38,7 @@ class GovukComponent::NotificationBannerComponent < GovukComponent::Base
       @link_text = link_text
       @link_href = link_href
 
-      super(classes: classes, html_attributes: html_attributes)
+      super(classes:, html_attributes:)
     end
 
     def call
@@ -72,7 +72,7 @@ private
         "module" => "#{brand}-notification-banner",
         "disable-auto-focus" => disable_auto_focus
       },
-      role: role,
+      role:,
       aria: { labelledby: title_id },
     }
   end

--- a/app/components/govuk_component/pagination_component.rb
+++ b/app/components/govuk_component/pagination_component.rb
@@ -16,23 +16,23 @@ class GovukComponent::PaginationComponent < GovukComponent::Base
 
   renders_one :next_page, ->(href:, text: default_adjacent_text(:next), label_text: nil, classes: [], html_attributes: {}) do
     GovukComponent::PaginationComponent::NextPage.new(
-      text: text,
-      href: href,
-      label_text: label_text,
+      text:,
+      href:,
+      label_text:,
       block_mode: block_mode?,
-      classes: classes,
-      html_attributes: html_attributes
+      classes:,
+      html_attributes:
     )
   end
 
   renders_one :previous_page, ->(href:, text: default_adjacent_text(:prev), label_text: nil, classes: [], html_attributes: {}) do
     GovukComponent::PaginationComponent::PreviousPage.new(
-      text: text,
-      href: href,
-      label_text: label_text,
+      text:,
+      href:,
+      label_text:,
       block_mode: block_mode?,
-      classes: classes,
-      html_attributes: html_attributes
+      classes:,
+      html_attributes:
     )
   end
 
@@ -49,7 +49,7 @@ class GovukComponent::PaginationComponent < GovukComponent::Base
     @block_mode                    = block_mode
     @landmark_label                = landmark_label
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def before_render

--- a/app/components/govuk_component/pagination_component/adjacent_page.rb
+++ b/app/components/govuk_component/pagination_component/adjacent_page.rb
@@ -9,12 +9,12 @@ class GovukComponent::PaginationComponent::AdjacentPage < GovukComponent::Base
     @block_mode           = block_mode
     @suffix               = suffix
 
-    super(html_attributes: html_attributes, classes: classes)
+    super(html_attributes:, classes:)
   end
 
   def call
     tag.div(**html_attributes) do
-      tag.a(href: href, class: ["#{brand}-link", "#{brand}-pagination__link"], rel: suffix) do
+      tag.a(href:, class: ["#{brand}-link", "#{brand}-pagination__link"], rel: suffix) do
         safe_join([body, divider, label_content])
       end
     end

--- a/app/components/govuk_component/pagination_component/item.rb
+++ b/app/components/govuk_component/pagination_component/item.rb
@@ -22,7 +22,7 @@ class GovukComponent::PaginationComponent::Item < GovukComponent::Base
     # ignored
     @mode = from_pagy ? pagy_mode(number) : manual_mode(ellipsis, current)
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call
@@ -56,7 +56,7 @@ private
     attributes = html_attributes.tap { |ha| ha[:class] << "#{brand}-pagination__item--current" if current }
 
     tag.li(**attributes) do
-      tag.a(href: href, class: ["#{brand}-link", "#{brand}-pagination__link"]) { number.to_s }
+      tag.a(href:, class: ["#{brand}-link", "#{brand}-pagination__link"]) { number.to_s }
     end
   end
 

--- a/app/components/govuk_component/pagination_component/next_page.rb
+++ b/app/components/govuk_component/pagination_component/next_page.rb
@@ -2,12 +2,12 @@ class GovukComponent::PaginationComponent::NextPage < GovukComponent::Pagination
   def initialize(href:, text:, label_text: nil, block_mode: true, classes: [], html_attributes: {})
     super(
       suffix: "next",
-      text: text,
-      href: href,
-      label_text: label_text,
-      block_mode: block_mode,
-      classes: classes,
-      html_attributes: html_attributes
+      text:,
+      href:,
+      label_text:,
+      block_mode:,
+      classes:,
+      html_attributes:
     )
   end
 

--- a/app/components/govuk_component/pagination_component/previous_page.rb
+++ b/app/components/govuk_component/pagination_component/previous_page.rb
@@ -2,12 +2,12 @@ class GovukComponent::PaginationComponent::PreviousPage < GovukComponent::Pagina
   def initialize(href:, text:, label_text: nil, block_mode: true, classes: [], html_attributes: {})
     super(
       suffix: "prev",
-      text: text,
-      href: href,
-      label_text: label_text,
-      block_mode: block_mode,
-      classes: classes,
-      html_attributes: html_attributes
+      text:,
+      href:,
+      label_text:,
+      block_mode:,
+      classes:,
+      html_attributes:
     )
   end
 

--- a/app/components/govuk_component/panel_component.rb
+++ b/app/components/govuk_component/panel_component.rb
@@ -9,11 +9,11 @@ class GovukComponent::PanelComponent < GovukComponent::Base
     @text          = text
     @id            = id
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call
-    tag.div(id: id, **html_attributes) do
+    tag.div(id:, **html_attributes) do
       safe_join([panel_title, panel_body].compact)
     end
   end

--- a/app/components/govuk_component/phase_banner_component.rb
+++ b/app/components/govuk_component/phase_banner_component.rb
@@ -10,7 +10,7 @@ class GovukComponent::PhaseBannerComponent < GovukComponent::Base
     @phase_tag = tag
     @text      = text
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def phase_tag_component

--- a/app/components/govuk_component/section_break_component.rb
+++ b/app/components/govuk_component/section_break_component.rb
@@ -10,7 +10,7 @@ class GovukComponent::SectionBreakComponent < GovukComponent::Base
     @visible = visible
     @size    = size
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call

--- a/app/components/govuk_component/start_button_component.rb
+++ b/app/components/govuk_component/start_button_component.rb
@@ -6,7 +6,7 @@ class GovukComponent::StartButtonComponent < GovukComponent::Base
     @href = href
     @as_button = as_button
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call

--- a/app/components/govuk_component/summary_list_component.rb
+++ b/app/components/govuk_component/summary_list_component.rb
@@ -6,8 +6,8 @@ module GovukComponent
       GovukComponent::SummaryListComponent::RowComponent.new(
         show_actions_column: @show_actions_column,
         visually_hidden_action_suffix: visually_hidden_action_suffix || card&.title,
-        classes: classes,
-        html_attributes: html_attributes,
+        classes:,
+        html_attributes:,
         &block
       )
     end
@@ -18,7 +18,7 @@ module GovukComponent
       @card                          = GovukComponent::SummaryListComponent::CardComponent.new(**card) if card.present?
       @visually_hidden_action_suffix = visually_hidden_action_suffix
 
-      super(classes: classes, html_attributes: html_attributes)
+      super(classes:, html_attributes:)
 
       return unless rows.presence
 

--- a/app/components/govuk_component/summary_list_component/action_component.rb
+++ b/app/components/govuk_component/summary_list_component/action_component.rb
@@ -8,7 +8,7 @@ class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Ba
       fail(ArgumentError, "missing keyword: visually_hidden_text")
     end
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
     @href = href
     @text = text
     @visually_hidden_action_suffix = visually_hidden_action_suffix

--- a/app/components/govuk_component/summary_list_component/card_component.rb
+++ b/app/components/govuk_component/summary_list_component/card_component.rb
@@ -8,7 +8,7 @@ class GovukComponent::SummaryListComponent::CardComponent < GovukComponent::Base
     @title = title
     actions.each { |a| with_action { a } } if actions.any?
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
 private

--- a/app/components/govuk_component/summary_list_component/key_component.rb
+++ b/app/components/govuk_component/summary_list_component/key_component.rb
@@ -4,7 +4,7 @@ class GovukComponent::SummaryListComponent::KeyComponent < GovukComponent::Base
   def initialize(text: nil, classes: [], html_attributes: {})
     @text = text
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call

--- a/app/components/govuk_component/summary_list_component/row_component.rb
+++ b/app/components/govuk_component/summary_list_component/row_component.rb
@@ -5,12 +5,12 @@ class GovukComponent::SummaryListComponent::RowComponent < GovukComponent::Base
   renders_one :value, GovukComponent::SummaryListComponent::ValueComponent
   renders_many :actions, ->(href: nil, text: 'Change', visually_hidden_text: false, classes: [], html_attributes: {}, &block) do
     GovukComponent::SummaryListComponent::ActionComponent.new(
-      href: href,
-      text: text,
-      visually_hidden_text: visually_hidden_text,
-      visually_hidden_action_suffix: visually_hidden_action_suffix,
-      classes: classes,
-      html_attributes: html_attributes,
+      href:,
+      text:,
+      visually_hidden_text:,
+      visually_hidden_action_suffix:,
+      classes:,
+      html_attributes:,
       &block
     )
   end
@@ -19,7 +19,7 @@ class GovukComponent::SummaryListComponent::RowComponent < GovukComponent::Base
     @show_actions_column = show_actions_column
     @visually_hidden_action_suffix = visually_hidden_action_suffix
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call

--- a/app/components/govuk_component/summary_list_component/value_component.rb
+++ b/app/components/govuk_component/summary_list_component/value_component.rb
@@ -2,7 +2,7 @@ class GovukComponent::SummaryListComponent::ValueComponent < GovukComponent::Bas
   attr_reader :text
 
   def initialize(text: nil, classes: [], html_attributes: {})
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
 
     @text = text
   end

--- a/app/components/govuk_component/tab_component.rb
+++ b/app/components/govuk_component/tab_component.rb
@@ -9,13 +9,13 @@ class GovukComponent::TabComponent < GovukComponent::Base
     @title = title
     @id    = id
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
 private
 
   def default_attributes
-    { id: id, class: "#{brand}-tabs", data: { module: "#{brand}-tabs" } }
+    { id:, class: "#{brand}-tabs", data: { module: "#{brand}-tabs" } }
   end
 
   class Tab < GovukComponent::Base
@@ -25,7 +25,7 @@ private
       @label = label
       @text  = h(text)
 
-      super(classes: classes, html_attributes: html_attributes)
+      super(classes:, html_attributes:)
     end
 
     def id(prefix: nil)
@@ -47,7 +47,7 @@ private
     end
 
     def default_attributes
-      { id: id, class: "#{brand}-tabs__panel" }
+      { id:, class: "#{brand}-tabs__panel" }
     end
 
     def combined_attributes(i)

--- a/app/components/govuk_component/table_component.rb
+++ b/app/components/govuk_component/table_component.rb
@@ -14,7 +14,7 @@ module GovukComponent
       @first_cell_is_header = first_cell_is_header
       @caption_text         = caption
 
-      super(classes: classes, html_attributes: html_attributes)
+      super(classes:, html_attributes:)
 
       # when no rows are passed in it's likely we're taking the slot approach
       return unless rows.presence
@@ -32,12 +32,12 @@ module GovukComponent
     def build(head_data, body_data, foot_data, caption_text)
       with_caption(text: caption_text)
       with_head(rows: [head_data])
-      with_body(rows: body_data, first_cell_is_header: first_cell_is_header)
-      with_foot(rows: foot_data, first_cell_is_header: first_cell_is_header)
+      with_body(rows: body_data, first_cell_is_header:)
+      with_foot(rows: foot_data, first_cell_is_header:)
     end
 
     def default_attributes
-      { id: id, class: "#{brand}-table" }
+      { id:, class: "#{brand}-table" }
     end
   end
 end

--- a/app/components/govuk_component/table_component/body_component.rb
+++ b/app/components/govuk_component/table_component/body_component.rb
@@ -1,16 +1,16 @@
 class GovukComponent::TableComponent::BodyComponent < GovukComponent::Base
   renders_many :rows, ->(cell_data: nil, first_cell_is_header: false, classes: [], html_attributes: {}, &block) do
     GovukComponent::TableComponent::RowComponent.from_body(
-      cell_data: cell_data,
-      first_cell_is_header: first_cell_is_header,
-      classes: classes,
-      html_attributes: html_attributes,
+      cell_data:,
+      first_cell_is_header:,
+      classes:,
+      html_attributes:,
       &block
     )
   end
 
   def initialize(rows: nil, first_cell_is_header: false, classes: [], html_attributes: {})
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
 
     build_rows_from_row_data(rows, first_cell_is_header)
   end
@@ -24,7 +24,7 @@ private
   def build_rows_from_row_data(data, first_cell_is_header)
     return if data.blank?
 
-    data.each { |d| with_row(cell_data: d, first_cell_is_header: first_cell_is_header) }
+    data.each { |d| with_row(cell_data: d, first_cell_is_header:) }
   end
 
   def default_attributes

--- a/app/components/govuk_component/table_component/caption_component.rb
+++ b/app/components/govuk_component/table_component/caption_component.rb
@@ -8,7 +8,7 @@ class GovukComponent::TableComponent::CaptionComponent < GovukComponent::Base
     @text = text
     @size = size
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call

--- a/app/components/govuk_component/table_component/cell_component.rb
+++ b/app/components/govuk_component/table_component/cell_component.rb
@@ -25,7 +25,7 @@ class GovukComponent::TableComponent::CellComponent < GovukComponent::Base
     @rowspan = rowspan
     @header  = (header.nil?) ? in_thead? : header
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call
@@ -51,11 +51,11 @@ private
   end
 
   def default_attributes
-    { class: default_classes, scope: determine_scope, colspan: colspan, rowspan: rowspan }.compact
+    { class: default_classes, scope: determine_scope, colspan:, rowspan: }.compact
   end
 
   def determine_scope
-    conditions = { scope: scope, parent: parent, header: header, auto_table_scopes: config.enable_auto_table_scopes }
+    conditions = { scope:, parent:, header:, auto_table_scopes: config.enable_auto_table_scopes }
 
     case conditions
     in { scope: String }

--- a/app/components/govuk_component/table_component/col_group_component.rb
+++ b/app/components/govuk_component/table_component/col_group_component.rb
@@ -2,7 +2,7 @@ class GovukComponent::TableComponent::ColGroupComponent < GovukComponent::Base
   renders_many :cols, "ColComponent"
 
   def initialize(classes: [], cols: [], html_attributes: {})
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
 
     return if cols.blank?
 
@@ -29,11 +29,11 @@ private
     def initialize(span: 1, classes: [], html_attributes: {})
       @span = span.to_s
 
-      super(classes: classes, html_attributes: html_attributes)
+      super(classes:, html_attributes:)
     end
 
     def call
-      tag.col(span: span, **html_attributes)
+      tag.col(span:, **html_attributes)
     end
 
   private

--- a/app/components/govuk_component/table_component/foot_component.rb
+++ b/app/components/govuk_component/table_component/foot_component.rb
@@ -1,10 +1,10 @@
 class GovukComponent::TableComponent::FootComponent < GovukComponent::Base
   renders_many :rows, ->(cell_data: nil, first_cell_is_header: false, classes: [], html_attributes: {}, &block) do
     GovukComponent::TableComponent::RowComponent.from_foot(
-      cell_data: cell_data,
-      first_cell_is_header: first_cell_is_header,
-      classes: classes,
-      html_attributes: html_attributes,
+      cell_data:,
+      first_cell_is_header:,
+      classes:,
+      html_attributes:,
       &block
     )
   end
@@ -15,7 +15,7 @@ class GovukComponent::TableComponent::FootComponent < GovukComponent::Base
     @rows = rows
     @first_cell_is_header = first_cell_is_header
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
 
     return unless rows.presence
 
@@ -35,7 +35,7 @@ private
   def build_rows_from_row_data(data)
     return if data.blank?
 
-    with_row(cell_data: data, first_cell_is_header: first_cell_is_header)
+    with_row(cell_data: data, first_cell_is_header:)
   end
 
   def default_attributes

--- a/app/components/govuk_component/table_component/head_component.rb
+++ b/app/components/govuk_component/table_component/head_component.rb
@@ -1,9 +1,9 @@
 class GovukComponent::TableComponent::HeadComponent < GovukComponent::Base
   renders_many :rows, ->(cell_data: nil, classes: [], html_attributes: {}, &block) do
     GovukComponent::TableComponent::RowComponent.from_head(
-      cell_data: cell_data,
-      classes: classes,
-      html_attributes: html_attributes,
+      cell_data:,
+      classes:,
+      html_attributes:,
       &block
     )
   end
@@ -11,7 +11,7 @@ class GovukComponent::TableComponent::HeadComponent < GovukComponent::Base
   attr_reader :row_data
 
   def initialize(rows: nil, classes: [], html_attributes: {})
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
 
     build_rows_from_row_data(rows)
   end

--- a/app/components/govuk_component/table_component/row_component.rb
+++ b/app/components/govuk_component/table_component/row_component.rb
@@ -1,16 +1,16 @@
 class GovukComponent::TableComponent::RowComponent < GovukComponent::Base
   renders_many :cells, ->(scope: nil, header: nil, text: nil, numeric: false, width: nil, rowspan: nil, colspan: nil, classes: [], html_attributes: {}, &block) do
     GovukComponent::TableComponent::CellComponent.new(
-      scope: scope,
-      header: header,
-      text: text,
-      numeric: numeric,
-      width: width,
-      parent: parent,
-      rowspan: rowspan,
-      colspan: colspan,
-      classes: classes,
-      html_attributes: html_attributes,
+      scope:,
+      header:,
+      text:,
+      numeric:,
+      width:,
+      parent:,
+      rowspan:,
+      colspan:,
+      classes:,
+      html_attributes:,
       &block
     )
   end
@@ -21,7 +21,7 @@ class GovukComponent::TableComponent::RowComponent < GovukComponent::Base
     @first_cell_is_header = first_cell_is_header
     @parent = parent
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
 
     build_cells_from_cell_data(cell_data)
   end

--- a/app/components/govuk_component/tag_component.rb
+++ b/app/components/govuk_component/tag_component.rb
@@ -7,7 +7,7 @@ class GovukComponent::TagComponent < GovukComponent::Base
     @text   = text
     @colour = colour
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call

--- a/app/components/govuk_component/task_list_component.rb
+++ b/app/components/govuk_component/task_list_component.rb
@@ -2,14 +2,14 @@ module GovukComponent
   class TaskListComponent < GovukComponent::Base
     renders_many :items, ->(title: nil, href: nil, hint: nil, status: {}, classes: [], html_attributes: {}) do
       GovukComponent::TaskListComponent::ItemComponent.new(
-        title: title,
-        href: href,
-        hint: hint,
+        title:,
+        href:,
+        hint:,
         id_prefix: @id_prefix,
         count: @count,
-        status: status,
-        classes: classes,
-        html_attributes: html_attributes
+        status:,
+        classes:,
+        html_attributes:
       )
     end
 
@@ -17,7 +17,7 @@ module GovukComponent
       @id_prefix = id_prefix
       @count = 0
 
-      super(classes: classes, html_attributes: html_attributes)
+      super(classes:, html_attributes:)
     end
 
     def call

--- a/app/components/govuk_component/task_list_component/item_component.rb
+++ b/app/components/govuk_component/task_list_component/item_component.rb
@@ -4,10 +4,10 @@ module GovukComponent
       GovukComponent::TaskListComponent::StatusComponent.new(
         id_prefix: @id_prefix,
         count: @count,
-        text: text,
-        cannot_start_yet: cannot_start_yet,
-        classes: classes,
-        html_attributes: html_attributes,
+        text:,
+        cannot_start_yet:,
+        classes:,
+        html_attributes:,
         &block
       )
     end
@@ -16,11 +16,11 @@ module GovukComponent
       GovukComponent::TaskListComponent::TitleComponent.new(
         id_prefix: @id_prefix,
         count: @count,
-        text: text,
-        href: href,
-        hint: hint,
-        classes: classes,
-        html_attributes: html_attributes,
+        text:,
+        href:,
+        hint:,
+        classes:,
+        html_attributes:,
         &block
       )
     end
@@ -36,7 +36,7 @@ module GovukComponent
       @id_prefix  = id_prefix
       @count      = count
 
-      super(classes: classes, html_attributes: html_attributes)
+      super(classes:, html_attributes:)
     end
 
     def call
@@ -68,7 +68,7 @@ module GovukComponent
     end
 
     def title_attributes
-      { text: raw_title, href: href, hint: hint }
+      { text: raw_title, href:, hint: }
     end
 
     def html_attributes_with_link_class

--- a/app/components/govuk_component/task_list_component/status_component.rb
+++ b/app/components/govuk_component/task_list_component/status_component.rb
@@ -8,7 +8,7 @@ module GovukComponent
       @id_prefix        = id_prefix
       @cannot_start_yet = cannot_start_yet
 
-      super(classes: classes, html_attributes: html_attributes)
+      super(classes:, html_attributes:)
     end
 
     def call

--- a/app/components/govuk_component/task_list_component/title_component.rb
+++ b/app/components/govuk_component/task_list_component/title_component.rb
@@ -11,7 +11,7 @@ module GovukComponent
       @id_prefix  = id_prefix
       @count      = count
 
-      super(classes: classes, html_attributes: html_attributes)
+      super(classes:, html_attributes:)
     end
 
     def call

--- a/app/components/govuk_component/warning_text_component.rb
+++ b/app/components/govuk_component/warning_text_component.rb
@@ -6,7 +6,7 @@ class GovukComponent::WarningTextComponent < GovukComponent::Base
     @icon = icon
     @icon_fallback_text = icon_fallback_text
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call

--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -4,8 +4,8 @@ module GovukLinkHelper
   using HTMLAttributesUtils
 
   def govuk_link_to(name, href = nil, new_tab: false, inverse: false, muted: false, no_underline: false, no_visited_state: false, text_colour: false, visually_hidden_prefix: nil, visually_hidden_suffix: nil, **kwargs, &block)
-    link_args = extract_link_args(new_tab: new_tab, inverse: inverse, muted: muted, no_underline: no_underline, no_visited_state: no_visited_state, text_colour: text_colour, **kwargs)
-    link_text = build_text(name, visually_hidden_prefix: visually_hidden_prefix, visually_hidden_suffix: visually_hidden_suffix)
+    link_args = extract_link_args(new_tab:, inverse:, muted:, no_underline:, no_visited_state:, text_colour:, **kwargs)
+    link_text = build_text(name, visually_hidden_prefix:, visually_hidden_suffix:)
 
     if block_given?
       link_to(link_text, **link_args, &block)
@@ -15,15 +15,15 @@ module GovukLinkHelper
   end
 
   def govuk_mail_to(email_address, name = nil, new_tab: false, inverse: false, muted: false, no_underline: false, no_visited_state: false, text_colour: false, visually_hidden_prefix: nil, visually_hidden_suffix: nil, **kwargs, &block)
-    link_args = extract_link_args(new_tab: new_tab, inverse: inverse, muted: muted, no_underline: no_underline, no_visited_state: no_visited_state, text_colour: text_colour, **kwargs)
-    link_text = build_text(name, visually_hidden_prefix: visually_hidden_prefix, visually_hidden_suffix: visually_hidden_suffix)
+    link_args = extract_link_args(new_tab:, inverse:, muted:, no_underline:, no_visited_state:, text_colour:, **kwargs)
+    link_text = build_text(name, visually_hidden_prefix:, visually_hidden_suffix:)
 
     mail_to(email_address, link_text, **link_args, &block)
   end
 
   def govuk_button_to(name, href = nil, disabled: false, inverse: false, secondary: false, warning: false, visually_hidden_prefix: nil, visually_hidden_suffix: nil, **kwargs, &block)
-    button_args = extract_button_args(new_tab: false, disabled: disabled, inverse: inverse, secondary: secondary, warning: warning, **kwargs)
-    button_text = build_text(name, visually_hidden_prefix: visually_hidden_prefix, visually_hidden_suffix: visually_hidden_suffix)
+    button_args = extract_button_args(new_tab: false, disabled:, inverse:, secondary:, warning:, **kwargs)
+    button_text = build_text(name, visually_hidden_prefix:, visually_hidden_suffix:)
 
     if block_given?
       button_to(name, **button_args, &block)
@@ -33,8 +33,8 @@ module GovukLinkHelper
   end
 
   def govuk_button_link_to(name, href = nil, new_tab: false, disabled: false, inverse: false, secondary: false, warning: false, visually_hidden_prefix: nil, visually_hidden_suffix: nil, **kwargs, &block)
-    button_args = extract_button_link_args(new_tab: new_tab, disabled: disabled, inverse: inverse, secondary: secondary, warning: warning, **kwargs)
-    button_text = build_text(name, visually_hidden_prefix: visually_hidden_prefix, visually_hidden_suffix: visually_hidden_suffix)
+    button_args = extract_button_link_args(new_tab:, disabled:, inverse:, secondary:, warning:, **kwargs)
+    button_text = build_text(name, visually_hidden_prefix:, visually_hidden_suffix:)
 
     if block_given?
       link_to(name, **button_args, &block)
@@ -91,7 +91,7 @@ private
     Rails.logger.warn(actions_warning_message(kwargs.fetch(:action))) if kwargs.key?(:action)
     Rails.logger.warn(controller_warning_message(kwargs.fetch(:controller))) if kwargs.key?(:controller)
 
-    link_classes = extract_link_classes(inverse: inverse, muted: muted, no_underline: no_underline, no_visited_state: no_visited_state, text_colour: text_colour)
+    link_classes = extract_link_classes(inverse:, muted:, no_underline:, no_visited_state:, text_colour:)
 
     { **link_classes, **new_tab_args(new_tab) }.deep_merge_html_attributes(kwargs)
   end
@@ -100,13 +100,13 @@ private
     Rails.logger.warn(actions_warning_message(kwargs.fetch(:action))) if kwargs.key?(:action)
     Rails.logger.warn(controller_warning_message(kwargs.fetch(:controller))) if kwargs.key?(:controller)
 
-    button_classes = extract_button_classes(inverse: inverse, secondary: secondary, warning: warning)
+    button_classes = extract_button_classes(inverse:, secondary:, warning:)
 
     { **button_classes, **button_attributes(disabled), **new_tab_args(new_tab) }.deep_merge_html_attributes(kwargs)
   end
 
   def extract_button_args(disabled: false, inverse: false, secondary: false, warning: false, **kwargs)
-    button_classes = extract_button_classes(inverse: inverse, secondary: secondary, warning: warning)
+    button_classes = extract_button_classes(inverse:, secondary:, warning:)
 
     { **button_classes, **button_attributes(disabled) }.deep_merge_html_attributes(kwargs)
   end
@@ -114,11 +114,11 @@ private
   def extract_link_classes(inverse: false, muted: false, no_underline: false, no_visited_state: false, text_colour: false)
     {
       class: govuk_link_classes(
-        inverse: inverse,
-        muted: muted,
-        no_underline: no_underline,
-        no_visited_state: no_visited_state,
-        text_colour: text_colour,
+        inverse:,
+        muted:,
+        no_underline:,
+        no_visited_state:,
+        text_colour:,
       )
     }
   end
@@ -126,9 +126,9 @@ private
   def extract_button_classes(inverse: false, secondary: false, warning: false)
     {
       class: govuk_button_classes(
-        inverse: inverse,
-        secondary: secondary,
-        warning: warning
+        inverse:,
+        secondary:,
+        warning:
       )
     }
   end

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -41,11 +41,11 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | Ruby
       td.govuk-table__cell.govuk-table__cell--numeric
+        | 3.3.0
+        br
         | 3.2.2
         br
         | 3.1.4
-        br
-        | 3.0.6
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.0.3
         br

--- a/guide/lib/helpers/content_helpers.rb
+++ b/guide/lib/helpers/content_helpers.rb
@@ -5,8 +5,8 @@ module Helpers
       rows = component_helper_mapping.to_a.map { |v| v.map { |c| "<code>#{c}</code>".html_safe } }
 
       GovukComponent::TableComponent.new(
-        head: head,
-        rows: rows,
+        head:,
+        rows:,
         caption: "Component to helper mappings"
       )
     end

--- a/spec/components/govuk_component/accordion_component_spec.rb
+++ b/spec/components/govuk_component/accordion_component_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe(GovukComponent::AccordionComponent, type: :component) do
     }
   end
 
-  let(:kwargs) { { html_attributes: { id: id } } }
+  let(:kwargs) { { html_attributes: { id: } } }
 
   subject! do
     render_inline(GovukComponent::AccordionComponent.new(**kwargs)) do |component|
       helper.safe_join(
         sections.map do |heading_text, content|
-          component.with_section(heading_text: heading_text) { content }
+          component.with_section(heading_text:) { content }
         end
       )
     end
@@ -36,7 +36,7 @@ RSpec.describe(GovukComponent::AccordionComponent, type: :component) do
     end
 
     specify 'the container div has the right id' do
-      expect(rendered_content).to have_tag('div', with: { id: id, class: component_css_class })
+      expect(rendered_content).to have_tag('div', with: { id:, class: component_css_class })
     end
   end
 
@@ -74,7 +74,7 @@ RSpec.describe(GovukComponent::AccordionComponent, type: :component) do
 
   describe 'building unique section ids' do
     context 'when the accordion has an ID' do
-      let(:kwargs) { { html_attributes: { id: id } } }
+      let(:kwargs) { { html_attributes: { id: } } }
 
       specify 'the accordion id is prefixes the section id' do
         expect(html.css('.govuk-accordion__section').map { |e| e[:id] }).to all(start_with(id))
@@ -157,7 +157,7 @@ RSpec.describe(GovukComponent::AccordionComponent, type: :component) do
 
       subject! do
         render_inline(GovukComponent::AccordionComponent.new) do |component|
-          component.with_section(heading_text: heading_text, summary_text: summary_text) { 'abc' }
+          component.with_section(heading_text:, summary_text:) { 'abc' }
         end
       end
 
@@ -177,7 +177,7 @@ RSpec.describe(GovukComponent::AccordionComponent, type: :component) do
 
       subject! do
         render_inline(GovukComponent::AccordionComponent.new(**kwargs)) do |component|
-          component.with_section(heading_text: heading_text) do |section|
+          component.with_section(heading_text:) do |section|
             section.with_summary_html do
               helper.content_tag(custom_tag, custom_text, class: custom_class)
             end

--- a/spec/components/govuk_component/back_link_component_spec.rb
+++ b/spec/components/govuk_component/back_link_component_spec.rb
@@ -3,30 +3,30 @@ require 'spec_helper'
 RSpec.describe(GovukComponent::BackLinkComponent, type: :component) do
   let(:default_text) { 'Back' }
   let(:href) { 'https://www.gov.uk/government/organisations/department-for-education' }
-  let(:kwargs) { { href: href } }
+  let(:kwargs) { { href: } }
   let(:component_css_class) { 'govuk-back-link' }
 
   subject! { render_inline(GovukComponent::BackLinkComponent.new(**kwargs)) }
 
   specify 'renders a link with the right href and text' do
-    expect(rendered_content).to have_tag('a', text: default_text, with: { href: href, class: component_css_class })
+    expect(rendered_content).to have_tag('a', text: default_text, with: { href:, class: component_css_class })
   end
 
   context 'when custom text is provided via the text argument' do
     let(:custom_text) { 'Department for Education' }
-    let(:kwargs) { { href: href, text: custom_text } }
+    let(:kwargs) { { href:, text: custom_text } }
 
     specify 'renders the component with custom text' do
-      expect(rendered_content).to have_tag('a', with: { href: href, class: component_css_class }, text: custom_text)
+      expect(rendered_content).to have_tag('a', with: { href:, class: component_css_class }, text: custom_text)
     end
   end
 
   context 'when back link colours are inverted' do
-    let(:kwargs) { { href: href, inverse: true } }
+    let(:kwargs) { { href:, inverse: true } }
     let(:expected_classes) { [component_css_class, "govuk-back-link--inverse"] }
 
     specify 'renders the component with the inverted colour class present' do
-      expect(rendered_content).to have_tag('a', with: { href: href, class: expected_classes }, text: default_text)
+      expect(rendered_content).to have_tag('a', with: { href:, class: expected_classes }, text: default_text)
     end
   end
 
@@ -34,13 +34,13 @@ RSpec.describe(GovukComponent::BackLinkComponent, type: :component) do
     let(:custom_text) { "Some text" }
     let(:custom_tag) { :code }
     subject! do
-      render_inline(GovukComponent::BackLinkComponent.new(href: href)) do
+      render_inline(GovukComponent::BackLinkComponent.new(href:)) do
         helper.content_tag(custom_tag, custom_text)
       end
     end
 
     specify 'renders the component with custom tag and text' do
-      expect(rendered_content).to have_tag('a', with: { href: href, class: component_css_class }) do
+      expect(rendered_content).to have_tag('a', with: { href:, class: component_css_class }) do
         with_tag(custom_tag, text: custom_text)
       end
     end

--- a/spec/components/govuk_component/breadcrumbs_component_spec.rb
+++ b/spec/components/govuk_component/breadcrumbs_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
     }
   end
 
-  let(:kwargs) { { breadcrumbs: breadcrumbs } }
+  let(:kwargs) { { breadcrumbs: } }
 
   let(:component_css_class) { 'govuk-breadcrumbs' }
 
@@ -60,7 +60,7 @@ RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
   end
 
   context 'when hide_in_print is enabled' do
-    let(:kwargs) { { breadcrumbs: breadcrumbs, hide_in_print: true } }
+    let(:kwargs) { { breadcrumbs:, hide_in_print: true } }
     let(:expected_class) { 'govuk-breadcrumbs.govuk-\!-display-none-print' }
 
     specify 'breadcrumbs are suppressed when printing' do
@@ -69,7 +69,7 @@ RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
   end
 
   context 'when collapse_on_mobile is true' do
-    let(:kwargs) { { breadcrumbs: breadcrumbs, collapse_on_mobile: true } }
+    let(:kwargs) { { breadcrumbs:, collapse_on_mobile: true } }
     let(:expected_class) { 'govuk-breadcrumbs.govuk-\!-display-none-print' }
 
     specify 'breadcrumbs are collapsed on mobile' do
@@ -78,7 +78,7 @@ RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
   end
 
   context 'when breadcrumb colours are inverted' do
-    let(:kwargs) { { breadcrumbs: breadcrumbs, inverse: true } }
+    let(:kwargs) { { breadcrumbs:, inverse: true } }
     let(:expected_class) { 'govuk-breadcrumbs.govuk-breadcrumbs--inverse' }
 
     specify 'breadcrumbs colours are inverted' do

--- a/spec/components/govuk_component/configuration/back_link_component_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/back_link_component_configuration_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe(GovukComponent::BackLinkComponent, type: :component) do
   let(:href) { 'https://www.gov.uk/government/organisations/department-for-education' }
-  let(:kwargs) { { href: href } }
+  let(:kwargs) { { href: } }
   let(:component_css_class) { 'govuk-back-link' }
 
   describe 'configuration' do
@@ -22,7 +22,7 @@ RSpec.describe(GovukComponent::BackLinkComponent, type: :component) do
       specify 'renders the component with overriden default text' do
         expect(rendered_content).to have_tag(
           'a',
-          with: { href: href, class: component_css_class },
+          with: { href:, class: component_css_class },
           text: overriden_default_text
         )
       end

--- a/spec/components/govuk_component/configuration/breadcrumbs_component_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/breadcrumbs_component_configuration_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
   let(:href) { 'https://www.gov.uk/government/organisations/department-for-education' }
   let(:link_text) { 'Organisations' }
   let(:breadcrumbs) { { link_text => href } }
-  let(:kwargs) { { breadcrumbs: breadcrumbs } }
+  let(:kwargs) { { breadcrumbs: } }
   let(:component_css_class) { 'govuk-breadcrumbs' }
 
   describe 'configuration' do
@@ -27,7 +27,7 @@ RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
           'div',
           with: { class: [component_css_class, collapse_on_mobile_css_class] },
         ) do
-          with_tag('a', text: link_text, with: { href: href })
+          with_tag('a', text: link_text, with: { href: })
         end
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
           'div',
           with: { class: [component_css_class, hide_in_print_css_class] },
         ) do
-          with_tag('a', text: link_text, with: { href: href })
+          with_tag('a', text: link_text, with: { href: })
         end
       end
     end

--- a/spec/components/govuk_component/configuration/pagination_component_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/pagination_component_configuration_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe(GovukComponent::PaginationComponent, type: :component) do
   let(:pagy) { Pagy.new(page: 2, count: 20, items: 5, size: [1, 1, 1, 1]) }
-  let(:kwargs) { { pagy: pagy } }
+  let(:kwargs) { { pagy: } }
 
   describe "configuration" do
     after { Govuk::Components.reset! }

--- a/spec/components/govuk_component/configuration/summary_list_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/summary_list_configuration_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
             sl.with_row do |row|
               row.with_key(text: "key one")
               row.with_value(text: "value one")
-              row.with_action(text: "action one", href: "/action-one", visually_hidden_text: visually_hidden_text)
+              row.with_action(text: "action one", href: "/action-one", visually_hidden_text:)
             end
           end
         end

--- a/spec/components/govuk_component/configuration/table_component_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/table_component_configuration_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe(GovukComponent::TableComponent::CellComponent, type: :component) do
   let(:text) { 'Content' }
-  let(:kwargs) { { text: text, header: true, parent: 'tbody' } }
+  let(:kwargs) { { text:, header: true, parent: 'tbody' } }
   let(:component_css_class) { 'govuk-table__cell' }
 
   describe 'configuration' do

--- a/spec/components/govuk_component/configuration/tag_component_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/tag_component_configuration_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe(GovukComponent::TagComponent, type: :component) do
   let(:text) { 'Alert' }
-  let(:kwargs) { { text: text } }
+  let(:kwargs) { { text: } }
   let(:component_css_class) { 'govuk-tag' }
 
   let(:default_colour) { "green" }

--- a/spec/components/govuk_component/details_component_spec.rb
+++ b/spec/components/govuk_component/details_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe(GovukComponent::DetailsComponent, type: :component) do
   let(:component_css_class) { 'govuk-details' }
   let(:summary_text) { 'The new Ribwich' }
   let(:text) { 'Now without lettuce' }
-  let(:kwargs) { { summary_text: summary_text, text: text } }
+  let(:kwargs) { { summary_text:, text: } }
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
@@ -19,7 +19,7 @@ RSpec.describe(GovukComponent::DetailsComponent, type: :component) do
           with_tag('span', with: { class: 'govuk-details__summary-text' }, text: summary_text)
         end
 
-        with_tag('div', with: { class: 'govuk-details__text' }, text: text)
+        with_tag('div', with: { class: 'govuk-details__text' }, text:)
       end
     end
   end

--- a/spec/components/govuk_component/exit_this_page_component_spec.rb
+++ b/spec/components/govuk_component/exit_this_page_component_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe(GovukComponent::ExitThisPageComponent, type: :component) do
 
     describe "activated_text" do
       let(:activated_text) { 'Exiting the page now' }
-      let(:kwargs) { { activated_text: activated_text } }
+      let(:kwargs) { { activated_text: } }
 
       specify "adds the i18n data attribute for activated text" do
         expect(element.attributes["data-i18n.activated"].value).to eql(activated_text)
@@ -87,7 +87,7 @@ RSpec.describe(GovukComponent::ExitThisPageComponent, type: :component) do
 
     describe "timed_out_text" do
       let(:timed_out_text) { 'Unfortunately Exit this page has expired.' }
-      let(:kwargs) { { timed_out_text: timed_out_text } }
+      let(:kwargs) { { timed_out_text: } }
 
       specify "adds the i18n data attribute for timed out" do
         expect(element.attributes["data-i18n.timed-out"].value).to eql(timed_out_text)
@@ -96,7 +96,7 @@ RSpec.describe(GovukComponent::ExitThisPageComponent, type: :component) do
 
     describe "press_two_more_times_text" do
       let(:press_two_more_times_text) { 'Shift, press 2 more times to leave.' }
-      let(:kwargs) { { press_two_more_times_text: press_two_more_times_text } }
+      let(:kwargs) { { press_two_more_times_text: } }
 
       specify "adds the i18n data attribute for press two more times" do
         expect(element.attributes["data-i18n.press-two-more-times"].value).to eql(press_two_more_times_text)
@@ -105,7 +105,7 @@ RSpec.describe(GovukComponent::ExitThisPageComponent, type: :component) do
 
     describe "press_one_more_time_text" do
       let(:press_one_more_time_text) { 'Shift, press 1 more times to leave.' }
-      let(:kwargs) { { press_one_more_time_text: press_one_more_time_text } }
+      let(:kwargs) { { press_one_more_time_text: } }
 
       specify "adds the i18n data attribute for press one more time" do
         expect(element.attributes["data-i18n.press-one-more-time"].value).to eql(press_one_more_time_text)

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
       end
 
       context "when meta items are provided" do
-        let(:kwargs) { { meta_items_title: heading_text, meta_items: meta_items } }
+        let(:kwargs) { { meta_items_title: heading_text, meta_items: } }
 
         specify "the title should be rendered but visually hidden" do
           expect(rendered_content).to have_tag("h2", text: heading_text, with: { class: "govuk-visually-hidden" })
@@ -78,7 +78,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
 
             meta_items.each do |text, href|
               with_tag("li", with: { class: "govuk-footer__inline-list-item" }) do
-                with_tag("a", with: { href: href }, text: text)
+                with_tag("a", with: { href: }, text:)
               end
             end
           end
@@ -93,7 +93,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
             { text: "Three", href: "/two" }
           ]
         end
-        let(:kwargs) { { meta_items_title: heading_text, meta_items: meta_items } }
+        let(:kwargs) { { meta_items_title: heading_text, meta_items: } }
 
         specify "each meta item is rendered" do
           expect(rendered_content).to have_tag(selector) do
@@ -164,7 +164,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
     end
 
     describe "adding custom content under the meta items list" do
-      let(:kwargs) { { meta_items_title: heading_text, meta_items: meta_items } }
+      let(:kwargs) { { meta_items_title: heading_text, meta_items: } }
 
       subject! do
         render_inline(GovukComponent::FooterComponent.new(**kwargs)) do |footer|
@@ -223,7 +223,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
   end
 
   describe "overwriting all meta information entirely with custom content" do
-    let(:kwargs) { { meta_items_title: heading_text, meta_items: meta_items } }
+    let(:kwargs) { { meta_items_title: heading_text, meta_items: } }
 
     subject! do
       render_inline(GovukComponent::FooterComponent.new(**kwargs)) do |footer|
@@ -247,7 +247,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
   describe "replacing the default copyright information" do
     let(:copyright_text) { "Copyright goes here" }
     let(:copyright_url) { "https://www.copyright.info" }
-    let(:kwargs) { { copyright_text: copyright_text, copyright_url: copyright_url } }
+    let(:kwargs) { { copyright_text:, copyright_url: } }
 
     specify "the custom copyright text and link are rendered" do
       expect(rendered_content).to have_tag(selector) do

--- a/spec/components/govuk_component/header_component_spec.rb
+++ b/spec/components/govuk_component/header_component_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
 
   let(:all_kwargs) do
     {
-      homepage_url: homepage_url,
-      service_name: service_name,
-      service_url: service_url
+      homepage_url:,
+      service_name:,
+      service_url:
     }
   end
   let(:kwargs) { all_kwargs }

--- a/spec/components/govuk_component/inset_text_component_spec.rb
+++ b/spec/components/govuk_component/inset_text_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe(GovukComponent::InsetTextComponent, type: :component) do
   let(:component_css_class) { 'govuk-inset-text' }
 
   let(:text) { 'Bake him away, toys.' }
-  let(:kwargs) { { text: text } }
+  let(:kwargs) { { text: } }
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
@@ -14,7 +14,7 @@ RSpec.describe(GovukComponent::InsetTextComponent, type: :component) do
     before { render_inline(described_class.new(**kwargs)) }
 
     specify 'the text is rendered' do
-      expect(rendered_content).to have_tag('div', with: { class: component_css_class }, text: text)
+      expect(rendered_content).to have_tag('div', with: { class: component_css_class }, text:)
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe(GovukComponent::InsetTextComponent, type: :component) do
     before { render_inline(described_class.new(**kwargs.merge(id: custom_id))) }
 
     specify 'the text is rendered with the custom id' do
-      expect(rendered_content).to have_tag('div', with: { id: custom_id, class: component_css_class }, text: text)
+      expect(rendered_content).to have_tag('div', with: { id: custom_id, class: component_css_class }, text:)
     end
   end
 end

--- a/spec/components/govuk_component/notification_banner_component_spec.rb
+++ b/spec/components/govuk_component/notification_banner_component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
 
     context "when supplied with some text" do
       let(:text) { "Some custom text" }
-      let(:kwargs) { { title_text: title, text: text } }
+      let(:kwargs) { { title_text: title, text: } }
 
       subject! { render_inline(described_class.new(**kwargs)) }
 

--- a/spec/components/govuk_component/pagination_component_spec.rb
+++ b/spec/components/govuk_component/pagination_component_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe(GovukComponent::PaginationComponent, type: :component) do
   let(:count) { 30 }
   let(:items) { 5 }
   let(:size) { [1, 2, 2, 1] }
-  let(:defaults) { { count: count, items: items, size: size } }
+  let(:defaults) { { count:, items:, size: } }
   let(:current_page) { 2 }
   let(:pagy) { Pagy.new(page: current_page, **defaults) }
   let(:component_css_class) { 'govuk-pagination' }
 
-  let(:kwargs) { { pagy: pagy } }
+  let(:kwargs) { { pagy: } }
 
   subject! { render_inline(GovukComponent::PaginationComponent.new(**kwargs)) }
 
@@ -63,7 +63,7 @@ RSpec.describe(GovukComponent::PaginationComponent, type: :component) do
 
   context "when the landmark_label is overridden" do
     let(:custom_landmark_label) { "Events" }
-    let(:kwargs) { { pagy: pagy, landmark_label: custom_landmark_label } }
+    let(:kwargs) { { pagy:, landmark_label: custom_landmark_label } }
 
     specify "replaces the default landmark label with the custom one" do
       expect(rendered_content).to have_tag("nav", with: { "aria-label" => custom_landmark_label })
@@ -424,7 +424,7 @@ RSpec.describe(GovukComponent::PaginationComponent, type: :component) do
     context "when the next text is overridden" do
       let(:next_text) { "Proceed" }
 
-      subject! { render_inline(GovukComponent::PaginationComponent.new(next_text: next_text, pagy: pagy)) }
+      subject! { render_inline(GovukComponent::PaginationComponent.new(next_text:, pagy:)) }
 
       specify "the text value should be set correctly" do
         expect(rendered_content).to have_tag("div", with: { class: "govuk-pagination__next" }, text: next_text)
@@ -434,7 +434,7 @@ RSpec.describe(GovukComponent::PaginationComponent, type: :component) do
     context "when the previous text is overridden" do
       let(:previous_text) { "Regress" }
 
-      subject! { render_inline(GovukComponent::PaginationComponent.new(previous_text: previous_text, pagy: pagy)) }
+      subject! { render_inline(GovukComponent::PaginationComponent.new(previous_text:, pagy:)) }
 
       specify "the text value should be set correctly" do
         expect(rendered_content).to have_tag("div", with: { class: "govuk-pagination__prev" }, text: previous_text)

--- a/spec/components/govuk_component/panel_component_spec.rb
+++ b/spec/components/govuk_component/panel_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
 
   let(:title_text) { 'Springfield' }
   let(:text) { 'A noble spirit embiggens the smallest man' }
-  let(:kwargs) { { title_text: title_text, text: text } }
+  let(:kwargs) { { title_text:, text: } }
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
@@ -16,7 +16,7 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
 
     expect(rendered_content).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--confirmation) }) do
       with_tag('h1', with: { class: 'govuk-panel__title' }, text: title_text)
-      with_tag('div', with: { class: 'govuk-panel__body' }, text: text)
+      with_tag('div', with: { class: 'govuk-panel__body' }, text:)
     end
   end
 
@@ -52,7 +52,7 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
     specify 'contains a panel with no title and the text' do
       expect(rendered_content).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--confirmation) }) do
         without_tag('h1', with: { class: 'govuk-panel__title' }, text: title_text)
-        with_tag('div', with: { class: 'govuk-panel__body' }, text: text)
+        with_tag('div', with: { class: 'govuk-panel__body' }, text:)
       end
     end
   end
@@ -72,7 +72,7 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
     specify 'contains a panel with the title and no text' do
       expect(rendered_content).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--confirmation) }) do
         with_tag('h1', with: { class: 'govuk-panel__title' }, text: title_text)
-        without_tag('div', with: { class: 'govuk-panel__body' }, text: text)
+        without_tag('div', with: { class: 'govuk-panel__body' }, text:)
       end
     end
   end

--- a/spec/components/govuk_component/phase_banner_component_spec.rb
+++ b/spec/components/govuk_component/phase_banner_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe(GovukComponent::PhaseBannerComponent, type: :component) do
 
   let(:phase) { 'Gamma' }
   let(:text) { 'This is an experimental service – be cautious' }
-  let(:kwargs) { { tag: { text: phase }, text: text } }
+  let(:kwargs) { { tag: { text: phase }, text: } }
 
   subject! { render_inline(GovukComponent::PhaseBannerComponent.new(**kwargs)) }
 
@@ -13,7 +13,7 @@ RSpec.describe(GovukComponent::PhaseBannerComponent, type: :component) do
     expect(rendered_content).to have_tag("div", with: { class: "govuk-phase-banner" }) do
       with_tag("p", with: { class: "govuk-phase-banner__content" }) do
         with_tag("strong", text: phase, with: { class: "govuk-phase-banner__content__tag" })
-        with_tag("span", text: text, with: { class: "govuk-phase-banner__text" })
+        with_tag("span", text:, with: { class: "govuk-phase-banner__text" })
       end
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe(GovukComponent::PhaseBannerComponent, type: :component) do
   end
 
   context "when a custom phase tag colour is provided" do
-    let(:kwargs) { { tag: { text: phase, colour: 'orange' }, text: text } }
+    let(:kwargs) { { tag: { text: phase, colour: 'orange' }, text: } }
 
     specify "the phase tag has the right colour class" do
       expect(rendered_content).to have_tag("strong", with: { class: "govuk-tag--orange" }, text: phase)

--- a/spec/components/govuk_component/start_button_component_spec.rb
+++ b/spec/components/govuk_component/start_button_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe(GovukComponent::StartButtonComponent, type: :component) do
   let(:text) { 'Department for Education' }
   let(:href) { 'https://www.gov.uk/government/organisations/department-for-education' }
   let(:as_button) { false }
-  let(:kwargs) { { text: text, href: href, as_button: as_button } }
+  let(:kwargs) { { text:, href:, as_button: } }
 
   before do
     allow_any_instance_of(GovukComponent::StartButtonComponent)
@@ -17,7 +17,7 @@ RSpec.describe(GovukComponent::StartButtonComponent, type: :component) do
   context 'as a link' do
     specify 'renders a link element with the right text and href' do
       expected_classes = %w(govuk-button govuk-button--start)
-      expect(rendered_content).to have_tag('a', text: text, with: { class: expected_classes })
+      expect(rendered_content).to have_tag('a', text:, with: { class: expected_classes })
     end
 
     specify 'the link contains an SVG chevron' do
@@ -46,7 +46,7 @@ RSpec.describe(GovukComponent::StartButtonComponent, type: :component) do
 
     specify 'renders a button element with the right text and href' do
       expected_classes = %w(govuk-button govuk-button--start)
-      expect(rendered_content).to have_tag('button', text: text, with: { class: expected_classes })
+      expect(rendered_content).to have_tag('button', text:, with: { class: expected_classes })
     end
 
     specify 'the link contains an SVG chevron' do

--- a/spec/components/govuk_component/summary_list_card_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_card_component_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe(GovukComponent::SummaryListComponent::CardComponent, type: :compo
   let(:title) { "Some title" }
 
   subject! do
-    render_inline(described_class.new(title: title)) do |component|
-      component.with_summary_list(rows: rows)
+    render_inline(described_class.new(title:)) do |component|
+      component.with_summary_list(rows:)
     end
   end
 
@@ -91,8 +91,8 @@ RSpec.describe(GovukComponent::SummaryListComponent::CardComponent, type: :compo
     let(:actions) { %w[abc def] }
 
     subject! do
-      render_inline(described_class.new(title: title, actions: actions)) do |component|
-        component.with_summary_list(rows: rows)
+      render_inline(described_class.new(title:, actions:)) do |component|
+        component.with_summary_list(rows:)
       end
     end
 

--- a/spec/components/govuk_component/summary_list_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_component_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
   end
 
   describe "passing data directly into the summary list component" do
-    subject! { render_inline(described_class.new(rows: rows, actions: actions)) }
+    subject! { render_inline(described_class.new(rows:, actions:)) }
     let(:actions) { true }
 
     describe "setting keys, values and actions" do

--- a/spec/components/govuk_component/tab_component_spec.rb
+++ b/spec/components/govuk_component/tab_component_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
     }
   end
 
-  let(:kwargs) { { title: title } }
+  let(:kwargs) { { title: } }
 
   subject! do
     render_inline(GovukComponent::TabComponent.new(**kwargs)) do |component|
       tabs.each do |label, content|
-        component.with_tab(label: label) { content }
+        component.with_tab(label:) { content }
       end
     end
   end
@@ -92,7 +92,7 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
     subject! do
       render_inline(GovukComponent::TabComponent.new(**kwargs)) do |component|
         tabs.each do |label, content|
-          component.with_tab(label: label, text: content)
+          component.with_tab(label:, text: content)
         end
       end
     end
@@ -113,7 +113,7 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
   context 'slot arguments' do
     let(:slot) { :tab }
     let(:content) { -> { 'some swanky tab content' } }
-    let(:slot_kwargs) { { label: label } }
+    let(:slot_kwargs) { { label: } }
 
     it_behaves_like 'a component with a slot that accepts custom classes'
     it_behaves_like 'a component with a slot that accepts custom html attributes'

--- a/spec/components/govuk_component/table_component_spec.rb
+++ b/spec/components/govuk_component/table_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
   let(:component_css_class) { 'govuk-table' }
   let(:caption_text) { "What a nice table" }
 
-  let(:kwargs) { { id: id } }
+  let(:kwargs) { { id: } }
 
   subject! do
     render_inline(GovukComponent::TableComponent.new(**kwargs)) do |table|
@@ -35,7 +35,7 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
   end
 
   specify "table has the provided id" do
-    expect(rendered_content).to have_tag("table", with: { id: id })
+    expect(rendered_content).to have_tag("table", with: { id: })
   end
 
   specify "renders a thead element" do
@@ -78,7 +78,7 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
         let(:caption_text) { "Argument-supplied caption" }
 
         subject! do
-          render_inline(GovukComponent::TableComponent.new(**kwargs.merge(rows: rows, caption: caption_text)))
+          render_inline(GovukComponent::TableComponent.new(**kwargs.merge(rows:, caption: caption_text)))
         end
 
         specify "renders the caption with the provided text" do
@@ -92,7 +92,7 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
         let(:caption_text) { nil }
 
         subject! do
-          render_inline(GovukComponent::TableComponent.new(**kwargs.merge(rows: rows, caption: caption_text)))
+          render_inline(GovukComponent::TableComponent.new(**kwargs.merge(rows:, caption: caption_text)))
         end
 
         specify "renders no caption element" do
@@ -118,7 +118,7 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
           let(:body_rows) { rows[1..] }
 
           subject! do
-            render_inline(GovukComponent::TableComponent.new(**kwargs.merge(rows: rows)))
+            render_inline(GovukComponent::TableComponent.new(**kwargs.merge(rows:)))
           end
 
           specify "renders one header row" do
@@ -156,14 +156,14 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
           end
 
           subject! do
-            render_inline(GovukComponent::TableComponent.new(**kwargs.merge(head: head, rows: rows, foot: foot)))
+            render_inline(GovukComponent::TableComponent.new(**kwargs.merge(head:, rows:, foot:)))
           end
 
           specify "renders one thead row" do
             expect(rendered_content).to have_tag("table", with: { class: component_css_class }) do
               with_tag("thead", with: { class: "govuk-table__head" }) do
                 with_tag("tr", with: { class: "govuk-table__row" }, count: 1) do
-                  head.all? { |text| with_tag("th", text: text, with: { class: "govuk-table__header" }) }
+                  head.all? { |text| with_tag("th", text:, with: { class: "govuk-table__header" }) }
                 end
               end
             end
@@ -173,7 +173,7 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
             expect(rendered_content).to have_tag("table", with: { class: component_css_class }) do
               with_tag("tbody", with: { class: "govuk-table__body" }) do
                 with_tag("tr", with: { class: "govuk-table__row" }, count: 3) do
-                  rows.flatten.all? { |text| with_tag("td", text: text, with: { class: "govuk-table__cell" }) }
+                  rows.flatten.all? { |text| with_tag("td", text:, with: { class: "govuk-table__cell" }) }
                 end
               end
             end
@@ -183,7 +183,7 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
             expect(rendered_content).to have_tag("table", with: { class: component_css_class }) do
               with_tag("tfoot", with: { class: "govuk-table__foot" }) do
                 with_tag("tr", with: { class: "govuk-table__row" }, count: 1) do
-                  foot.all? { |text| with_tag("td", text: text, with: { class: "govuk-table__footer" }) }
+                  foot.all? { |text| with_tag("td", text:, with: { class: "govuk-table__footer" }) }
                 end
               end
             end
@@ -211,9 +211,9 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
           render_inline(
             GovukComponent::TableComponent.new(
               first_cell_is_header: true,
-              head: head,
-              rows: rows,
-              foot: foot
+              head:,
+              rows:,
+              foot:
             )
           )
         end
@@ -276,7 +276,7 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
       end
 
       subject! do
-        render_inline(GovukComponent::TableComponent.new(**kwargs.merge(head: head, rows: rows, first_cell_is_header: true)))
+        render_inline(GovukComponent::TableComponent.new(**kwargs.merge(head:, rows:, first_cell_is_header: true)))
       end
 
       specify "renders the table header" do
@@ -426,7 +426,7 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
 
             subject do
               render_inline(GovukComponent::TableComponent.new(**kwargs)) do |table|
-                table.with_caption(text: "Caption size: #{size}", size: size)
+                table.with_caption(text: "Caption size: #{size}", size:)
               end
             end
 
@@ -481,7 +481,7 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
         table.with_head do |head|
           head.with_row do |row|
             GovukComponent::TableComponent::CellComponent.widths.each_key do |width|
-              row.with_cell(text: width, header: true, width: width)
+              row.with_cell(text: width, header: true, width:)
             end
           end
         end

--- a/spec/components/govuk_component/tag_component_spec.rb
+++ b/spec/components/govuk_component/tag_component_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 RSpec.describe(GovukComponent::TagComponent, type: :component) do
   let(:text) { 'Alert' }
-  let(:kwargs) { { text: text } }
+  let(:kwargs) { { text: } }
   let(:component_css_class) { 'govuk-tag' }
 
   describe 'content' do
     subject! { render_inline(GovukComponent::TagComponent.new(**kwargs)) }
 
     specify 'renders strong element with right class and text' do
-      expect(rendered_content).to have_tag('strong', with: { class: component_css_class }, text: text)
+      expect(rendered_content).to have_tag('strong', with: { class: component_css_class }, text:)
     end
 
     context 'when content is supplied in a block' do
@@ -43,13 +43,13 @@ RSpec.describe(GovukComponent::TagComponent, type: :component) do
 
       GovukComponent::TagComponent::COLOURS.each do |colour|
         context %('colour: #{colour}') do
-          let(:kwargs) { { text: text, colour: colour } }
+          let(:kwargs) { { text:, colour: } }
 
           specify %(adds class .govuk-colour--#{colour}) do
             expect(rendered_content).to have_tag(
               'strong',
               with: { class: [component_css_class, "govuk-tag--#{colour}"] },
-              text: text
+              text:
             )
           end
         end
@@ -58,7 +58,7 @@ RSpec.describe(GovukComponent::TagComponent, type: :component) do
 
     context 'when invalid colours are provided' do
       let(:invalid_colour) { 'hotdog' }
-      subject { render_inline(GovukComponent::TagComponent.new(text: text, colour: invalid_colour)) }
+      subject { render_inline(GovukComponent::TagComponent.new(text:, colour: invalid_colour)) }
 
       specify %(raises an error when colour isn't supported) do
         expect { subject }.to raise_error(ArgumentError, /invalid tag colour/)

--- a/spec/components/govuk_component/task_list_component_spec.rb
+++ b/spec/components/govuk_component/task_list_component_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe(GovukComponent::TaskListComponent, type: :component) do
   let(:component_css_class) { 'govuk-task-list' }
   let(:id_prefix) { nil }
-  let(:kwargs) { { id_prefix: id_prefix }.compact }
+  let(:kwargs) { { id_prefix: }.compact }
   let(:list_item_one_kwargs) { { title: "One", status: "in progress" } }
   let(:list_item_two_kwargs) { { title: "Two", status: "ok" } }
 
@@ -37,11 +37,11 @@ RSpec.describe(GovukComponent::TaskListComponent, type: :component) do
       context "when href is present" do
         let(:href) { "/item-one" }
         let(:title) { "One" }
-        let(:list_item_one_kwargs) { { title: title, href: href } }
+        let(:list_item_one_kwargs) { { title:, href: } }
 
         specify "a link is rendered with the correct attributes" do
           expect(rendered_content).to have_tag("li", with: { class: %(govuk-task-list__item govuk-task-list__item--with-link) }) do
-            with_tag("a", with: { class: %w(govuk-link govuk-task-list__link), href: href }, text: title)
+            with_tag("a", with: { class: %w(govuk-link govuk-task-list__link), href: }, text: title)
           end
         end
       end
@@ -167,7 +167,7 @@ RSpec.describe(GovukComponent::TaskListComponent, type: :component) do
           helper.safe_join(
             [
               item.with_title(text: title_text, hint: hint_text),
-              item.with_status(text: status_text, cannot_start_yet: cannot_start_yet),
+              item.with_status(text: status_text, cannot_start_yet:),
             ]
           )
         end
@@ -217,7 +217,7 @@ RSpec.describe(GovukComponent::TaskListComponent, type: :component) do
 
     subject! do
       render_inline(GovukComponent::TaskListComponent.new(**kwargs)) do |task_list|
-        task_list.with_item(title: "Sample", status: status)
+        task_list.with_item(title: "Sample", status:)
       end
     end
 
@@ -252,7 +252,7 @@ RSpec.describe(GovukComponent::TaskListComponent, type: :component) do
 
     subject! do
       render_inline(GovukComponent::TaskListComponent.new(**kwargs)) do |task_list|
-        task_list.with_item(title: "A thing", href: href, status: "Alright", hint: hint)
+        task_list.with_item(title: "A thing", href:, status: "Alright", hint:)
       end
     end
 

--- a/spec/components/govuk_component/warning_text_component_spec.rb
+++ b/spec/components/govuk_component/warning_text_component_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe(GovukComponent::WarningTextComponent, type: :component) do
   let(:component_css_class) { 'govuk-warning-text' }
   let(:custom_icon_fallback_text) { 'Informative text goes here' }
-  let(:kwargs) { { text: text } }
+  let(:kwargs) { { text: } }
   let(:text) { 'Some fancy warning' }
 
   subject! { render_inline(GovukComponent::WarningTextComponent.new(**kwargs)) }

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     context "when visually_hidden_prefix: 'some text'" do
       let(:visually_hidden_prefix) { "some prefix" }
       let(:visually_hidden_prefix_with_trailing_space) { "some prefix " }
-      let(:kwargs) { { visually_hidden_prefix: visually_hidden_prefix } }
+      let(:kwargs) { { visually_hidden_prefix: } }
 
       specify "the prefix is present and visually hidden" do
         expect(subject).to have_tag("a", text: /hello/, with: { href: "/world", class: "govuk-link" }) do
@@ -107,7 +107,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     context "when visually_hidden_suffix: 'some text'" do
       let(:visually_hidden_suffix) { "some suffix" }
       let(:visually_hidden_suffix_with_leading_space) { " some suffix" }
-      let(:kwargs) { { visually_hidden_suffix: visually_hidden_suffix } }
+      let(:kwargs) { { visually_hidden_suffix: } }
 
       specify "the suffix is present and visually hidden" do
         expect(subject).to have_tag("a", text: /hello/, with: { href: "/world", class: "govuk-link" }) do
@@ -232,7 +232,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     context "when visually_hidden_prefix: 'some text'" do
       let(:visually_hidden_prefix) { "some prefix" }
       let(:visually_hidden_prefix_with_trailing_space) { "some prefix " }
-      let(:kwargs) { { visually_hidden_prefix: visually_hidden_prefix } }
+      let(:kwargs) { { visually_hidden_prefix: } }
 
       specify "the prefix is present and visually hidden" do
         expect(subject).to have_tag("a", text: /hello/, with: { href: "mailto:world@solar.system", class: "govuk-link" }) do
@@ -248,7 +248,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     context "when visually_hidden_suffix: 'some text'" do
       let(:visually_hidden_suffix) { "some suffix" }
       let(:visually_hidden_suffix_with_leading_space) { " some suffix" }
-      let(:kwargs) { { visually_hidden_suffix: visually_hidden_suffix } }
+      let(:kwargs) { { visually_hidden_suffix: } }
 
       specify "the suffix is present and visually hidden" do
         expect(subject).to have_tag("a", text: /hello/, with: { href: "mailto:world@solar.system", class: "govuk-link" }) do
@@ -365,7 +365,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     context "when visually_hidden_prefix: 'some text'" do
       let(:visually_hidden_prefix) { "some prefix" }
       let(:visually_hidden_prefix_with_trailing_space) { "some prefix " }
-      let(:kwargs) { { visually_hidden_prefix: visually_hidden_prefix } }
+      let(:kwargs) { { visually_hidden_prefix: } }
 
       specify "the prefix is present and visually hidden" do
         expect(subject).to have_tag("a", text: /hello/, with: { href: "/world", class: "govuk-button" }) do
@@ -381,7 +381,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     context "when visually_hidden_suffix: 'some text'" do
       let(:visually_hidden_suffix) { "some suffix" }
       let(:visually_hidden_suffix_with_leading_space) { " some suffix" }
-      let(:kwargs) { { visually_hidden_suffix: visually_hidden_suffix } }
+      let(:kwargs) { { visually_hidden_suffix: } }
 
       specify "the suffix is present and visually hidden" do
         expect(subject).to have_tag("a", text: /hello/, with: { href: "/world", class: "govuk-button" }) do
@@ -500,7 +500,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     context "when visually_hidden_prefix: 'some text'" do
       let(:visually_hidden_prefix) { "some prefix" }
       let(:visually_hidden_prefix_with_trailing_space) { "some prefix " }
-      let(:kwargs) { { visually_hidden_prefix: visually_hidden_prefix } }
+      let(:kwargs) { { visually_hidden_prefix: } }
 
       specify "the prefix is present and visually hidden" do
         expect(subject).to have_tag("form", with: { method: "post", action: "/world" }) do
@@ -518,7 +518,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     context "when visually_hidden_suffix: 'some text'" do
       let(:visually_hidden_suffix) { "some suffix" }
       let(:visually_hidden_suffix_with_leading_space) { " some suffix" }
-      let(:kwargs) { { visually_hidden_suffix: visually_hidden_suffix } }
+      let(:kwargs) { { visually_hidden_suffix: } }
 
       specify "the suffix is present and visually hidden" do
         expect(subject).to have_tag("form", with: { method: "post", action: "/world" }) do


### PR DESCRIPTION
We try to support the latest 3 versions of Ruby. Ruby 3.3 was relased on Christmas day 2023 so now the three latest versions are 3.1, 3.2 and 3.3.

After the next point release, 3.0 will no longer be supported. 3.0 will stop working because the gem has switched to [shorthand hash syntax](https://github.com/ruby/ruby/commit/c60dbcd1c55cd77a24c41d5e1a9555622be8b2b8).

## Changes

- Update supported Ruby version documentation
- Apply Rubocop hash syntax fixes
- Update supported Ruby versions in GitHub actions
