### PR TITLE
Make the inverse button example use govuk blue

### DIFF
--- a/guide/content/stylesheets/components/_example.scss
+++ b/guide/content/stylesheets/components/_example.scss
@@ -18,6 +18,11 @@
     // make dark so the inverted hyperlinks (where the text is white) are visible
     &.inverse {
       background: govuk-colour('blue');
+
+      // force the link text to be govuk blue so there's sufficient contrast
+      .govuk-button.govuk-button--inverse {
+        color: govuk-colour('blue');
+      }
     }
   }
 


### PR DESCRIPTION
This increases the contrast of the coloured text on a white background enough to make it accessible, previosuly it had a ratio of 4.06 and now it's 5.2
