### PR TITLE
Correct settings variables for link colours in guide

### DIFF
--- a/guide/content/stylesheets/application.scss
+++ b/guide/content/stylesheets/application.scss
@@ -7,8 +7,8 @@ $govuk-assets-path: "/assets/";
 $govuk-font-family: system-ui, sans-serif;
 $govuk-brand-colour: #2288aa;
 $govuk-link-colour: #006688;
-$govuk-hover-colour: #004466;
-$govuk-visited-colour: #333366;
+$govuk-link-hover-colour: #004466;
+$govuk-link-visited-colour: #333366;
 $govuk-page-width: 1100px;
 
 // Import GOV.UK Frontend


### PR DESCRIPTION
As originally spotted by @peteryates.