### PR TITLE
Add data-module and prevent-double-click to buttons

### DIFF
--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -115,16 +115,16 @@ private
     Rails.logger.warn(controller_warning_message(kwargs.fetch(:controller))) if kwargs.key?(:controller)
 
     button_classes = extract_button_classes(inverse:, secondary:, warning:)
-    data_module = { "data-module": "#{brand}-button-to" }
+    data_attributes = build_data_attributes("#{brand}-button")
 
-    { **button_classes, **data_module, **button_attributes(disabled), **new_tab_args(new_tab) }.deep_merge_html_attributes(kwargs)
+    { **button_classes, **data_attributes, **button_attributes(disabled), **new_tab_args(new_tab) }.deep_merge_html_attributes(kwargs)
   end
 
-  def extract_button_args(disabled: false, inverse: false, secondary: false, warning: false, **kwargs)
+  def extract_button_args(disabled: false, inverse: false, secondary: false, warning: false, prevent_double_click: nil, **kwargs)
     button_classes = extract_button_classes(inverse:, secondary:, warning:)
-    data_module = { "data-module": "#{brand}-button-to" }
+    data_attributes = build_data_attributes("#{brand}-button", prevent_double_click:)
 
-    { **button_classes, **data_module, **button_attributes(disabled) }.deep_merge_html_attributes(kwargs)
+    { **button_classes, **data_attributes, **button_attributes(disabled) }.deep_merge_html_attributes(kwargs)
   end
 
   def extract_link_classes(inverse: false, muted: false, no_underline: false, no_visited_state: false, text_colour: false)
@@ -184,6 +184,13 @@ private
 
   def controller_warning_message(value)
     "controller: '#{value}' parameter detected. Support for old style controller/action links has been removed. See https://github.com/x-govuk/govuk-components/releases/tag/v5.0.0"
+  end
+
+  def build_data_attributes(data_module, prevent_double_click: nil)
+    {
+      "data-module": data_module,
+      "data-prevent-double-click": prevent_double_click
+    }.compact
   end
 end
 

--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -115,14 +115,16 @@ private
     Rails.logger.warn(controller_warning_message(kwargs.fetch(:controller))) if kwargs.key?(:controller)
 
     button_classes = extract_button_classes(inverse:, secondary:, warning:)
+    data_module = { "data-module": "#{brand}-button-to" }
 
-    { **button_classes, **button_attributes(disabled), **new_tab_args(new_tab) }.deep_merge_html_attributes(kwargs)
+    { **button_classes, **data_module, **button_attributes(disabled), **new_tab_args(new_tab) }.deep_merge_html_attributes(kwargs)
   end
 
   def extract_button_args(disabled: false, inverse: false, secondary: false, warning: false, **kwargs)
     button_classes = extract_button_classes(inverse:, secondary:, warning:)
+    data_module = { "data-module": "#{brand}-button-to" }
 
-    { **button_classes, **button_attributes(disabled) }.deep_merge_html_attributes(kwargs)
+    { **button_classes, **data_module, **button_attributes(disabled) }.deep_merge_html_attributes(kwargs)
   end
 
   def extract_link_classes(inverse: false, muted: false, no_underline: false, no_visited_state: false, text_colour: false)

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     subject { govuk_button_link_to("hello", "/world", **kwargs) }
 
     specify "renders a link styled as a button with the correct class" do
-      expect(subject).to have_tag("a", text: "hello", with: { href: "/world", class: "govuk-button", "data-module": "govuk-button-to" })
+      expect(subject).to have_tag("a", text: "hello", with: { href: "/world", class: "govuk-button", "data-module": "govuk-button" })
     end
 
     context "when a custom brand is set" do
@@ -344,7 +344,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       end
 
       specify "attributes are branded" do
-        expect(subject).to have_tag("a", text: "hello", with: { href: "/world", class: "globex-corp-button", "data-module": "globex-corp-button-to" })
+        expect(subject).to have_tag("a", text: "hello", with: { href: "/world", class: "globex-corp-button", "data-module": "globex-corp-button" })
       end
     end
 
@@ -516,7 +516,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
     specify "renders a form with a button that has the right attributes and classes" do
       expect(subject).to have_tag("form", with: { method: "post", action: "/world" }) do
-        with_tag("button", with: { class: "govuk-button", "data-module": "govuk-button-to" }, text: "hello")
+        with_tag("button", with: { class: "govuk-button", "data-module": "govuk-button" }, text: "hello")
       end
     end
 
@@ -535,7 +535,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       specify "attributes are branded" do
         expect(subject).to have_tag("form", with: { method: "post", action: "/world" }) do
-          with_tag("button", with: { class: "globex-corp-button", "data-module": "globex-corp-button-to" }, text: "hello")
+          with_tag("button", with: { class: "globex-corp-button", "data-module": "globex-corp-button" }, text: "hello")
         end
       end
     end
@@ -674,6 +674,22 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
               lang: "en-GB",
             }
           )
+        end
+      end
+    end
+
+    context "without prevent_double_click set" do
+      specify "the attribute data-prevent-douple-click isn't present" do
+        expect(subject).not_to have_tag("button", with: { "data-prevent-double-click": true })
+      end
+    end
+
+    context "when prevent_double_click: true" do
+      let(:kwargs) { { prevent_double_click: true } }
+
+      specify "the attribute data-prevent-douple-click is enabled" do
+        expect(subject).to have_tag("form", with: { method: "post", action: "/world" }) do
+          with_tag("button", with: { "data-prevent-double-click": true })
         end
       end
     end

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -327,7 +327,25 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     subject { govuk_button_link_to("hello", "/world", **kwargs) }
 
     specify "renders a link styled as a button with the correct class" do
-      expect(subject).to have_tag("a", text: "hello", with: { href: "/world", class: "govuk-button" })
+      expect(subject).to have_tag("a", text: "hello", with: { href: "/world", class: "govuk-button", "data-module": "govuk-button-to" })
+    end
+
+    context "when a custom brand is set" do
+      let(:custom_brand) { "globex-corp" }
+
+      around do |ex|
+        Govuk::Components.configure do |conf|
+          conf.brand = custom_brand
+        end
+
+        ex.run
+
+        Govuk::Components.reset!
+      end
+
+      specify "attributes are branded" do
+        expect(subject).to have_tag("a", text: "hello", with: { href: "/world", class: "globex-corp-button", "data-module": "globex-corp-button-to" })
+      end
     end
 
     context "calling with a block of content" do
@@ -498,7 +516,27 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
     specify "renders a form with a button that has the right attributes and classes" do
       expect(subject).to have_tag("form", with: { method: "post", action: "/world" }) do
-        with_tag("button", with: { class: "govuk-button" }, text: "hello")
+        with_tag("button", with: { class: "govuk-button", "data-module": "govuk-button-to" }, text: "hello")
+      end
+    end
+
+    context "when a custom brand is set" do
+      let(:custom_brand) { "globex-corp" }
+
+      around do |ex|
+        Govuk::Components.configure do |conf|
+          conf.brand = custom_brand
+        end
+
+        ex.run
+
+        Govuk::Components.reset!
+      end
+
+      specify "attributes are branded" do
+        expect(subject).to have_tag("form", with: { method: "post", action: "/world" }) do
+          with_tag("button", with: { class: "globex-corp-button", "data-module": "globex-corp-button-to" }, text: "hello")
+        end
       end
     end
 


### PR DESCRIPTION
These features were present in the previous version of the link helper but didn't make it to the rewrite.