### PR TITLE
Add custom branding to govuk_button_to

### DIFF
--- a/app/helpers/govuk_rails_compatible_link_helper.rb
+++ b/app/helpers/govuk_rails_compatible_link_helper.rb
@@ -44,7 +44,7 @@ module GovukRailsCompatibleLinkHelper
   def govuk_button_to(name = nil, options = nil, extra_options = {}, &block)
     extra_options = options if block_given?
     html_options = {
-      data: { module: "govuk-button" }
+      data: { module: "#{brand}-button" }
     }
 
     if extra_options && extra_options[:prevent_double_click]

--- a/spec/helpers/govuk_rails_compatible_link_helper_spec.rb
+++ b/spec/helpers/govuk_rails_compatible_link_helper_spec.rb
@@ -219,6 +219,31 @@ RSpec.describe(GovukRailsCompatibleLinkHelper, type: 'helper') do
         end
       end
     end
+
+    context "when a custom brand is set" do
+      let(:custom_brand) { "globex-corp" }
+
+      around do |ex|
+        Govuk::Components.configure do |conf|
+          conf.brand = custom_brand
+        end
+
+        ex.run
+
+        Govuk::Components.reset!
+      end
+
+      subject { govuk_button_to("hello", "/globex") }
+
+      specify "the data-module attribute is branded" do
+        expect(subject).to have_tag("form") do
+          with_tag(
+            "button",
+            with: { "data-module": "#{custom_brand}-button" }
+          )
+        end
+      end
+    end
   end
 
   describe "#govuk_button_link_to" do
@@ -283,6 +308,26 @@ RSpec.describe(GovukRailsCompatibleLinkHelper, type: 'helper') do
 
       specify "renders a form with an button that has the custom classes" do
         expect(subject).to have_tag("a", with: { href: button_link_url, class: %w(govuk-button yellow) }, text: button_link_text)
+      end
+    end
+
+    context "when a custom brand is set" do
+      let(:custom_brand) { "globex-corp" }
+
+      around do |ex|
+        Govuk::Components.configure do |conf|
+          conf.brand = custom_brand
+        end
+
+        ex.run
+
+        Govuk::Components.reset!
+      end
+
+      subject { govuk_button_link_to(button_link_text, link_params) }
+
+      specify "the data-module attribute is branded" do
+        expect(subject).to have_tag("a", with: { "data-module": "globex-corp-button" })
       end
     end
   end


### PR DESCRIPTION
I also found that this was missing ... it's less useful than #513, but I went down this path before realising the right fix was to update the new link helpers to support `data-module` and `prevent-double-click`, so had this ready to go.

