### PR TITLE
Build copyright when rendering instead of at init

### DIFF
--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -5,7 +5,7 @@ class GovukComponent::FooterComponent < GovukComponent::Base
   renders_one :meta
   renders_one :navigation
 
-  attr_reader :meta_items, :meta_text, :meta_items_title, :meta_licence, :copyright, :custom_container_classes
+  attr_reader :meta_items, :meta_text, :meta_items_title, :meta_licence, :copyright_text, :copyright_url, :custom_container_classes
 
   def initialize(
     classes: [],
@@ -27,7 +27,8 @@ class GovukComponent::FooterComponent < GovukComponent::Base
     @meta_licence                     = meta_licence
     @custom_meta_classes              = meta_classes
     @custom_meta_html_attributes      = meta_html_attributes
-    @copyright                        = build_copyright(copyright_text, copyright_url)
+    @copyright_text                   = copyright_text
+    @copyright_url                    = copyright_url
     @custom_container_classes         = container_classes
     @custom_container_html_attributes = container_html_attributes
 
@@ -81,7 +82,7 @@ private
     raw(%(All content is available under the #{link}, except where otherwise stated))
   end
 
-  def build_copyright(text, url)
-    link_to(text, url, class: "#{brand}-footer__link #{brand}-footer__copyright-logo")
+  def copyright
+    link_to(copyright_text, copyright_url, class: "#{brand}-footer__link #{brand}-footer__copyright-logo")
   end
 end


### PR DESCRIPTION
ViewComponent raises a `ControllerCalledBeforeRenderError` when rendering previews because we're calling `#link_to` at the point the component is initialized, which is problematic because the view context only exists once the ViewComponent is passed to the Rails render pipeline.

Setting `copyright_text` and `copyright_url` during initialization but combining them into a link with `#link_to` when rendering the component should alleviate this.

Fixes #512
