### PR TITLE
Add before and after links slots to footer

### DIFF
--- a/app/components/govuk_component/footer_component.html.erb
+++ b/app/components/govuk_component/footer_component.html.erb
@@ -15,7 +15,7 @@
         <div class="<%= brand %>-footer__meta-item <%= brand %>-footer__meta-item--grow">
           <% if meta_items.any? %>
             <h2 class="<%= brand %>-visually-hidden"><%= meta_items_title %></h2>
-
+            <%= content_before_meta_items %>
             <ul class="<%= brand %>-footer__inline-list">
               <% @meta_items.each do |hyperlink| %>
                 <li class="<%= brand %>-footer__inline-list-item">
@@ -23,6 +23,7 @@
                 </li>
               <% end %>
             </ul>
+            <%= content_after_meta_items %>
           <% end %>
 
           <% if meta_content.present? %>

--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -4,6 +4,8 @@ class GovukComponent::FooterComponent < GovukComponent::Base
   renders_one :meta_html
   renders_one :meta
   renders_one :navigation
+  renders_one :content_before_meta_items
+  renders_one :content_after_meta_items
 
   attr_reader :meta_items, :meta_text, :meta_items_title, :meta_licence, :copyright_text, :copyright_url, :custom_container_classes
 

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -117,6 +117,28 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
       end
     end
 
+    describe "content before and after meta items" do
+      let(:kwargs) { { meta_items: } }
+
+      subject! do
+        render_inline(GovukComponent::FooterComponent.new(**kwargs)) do |footer|
+          footer.with_content_before_meta_items { "before" }
+          footer.with_content_after_meta_items { "after" }
+        end
+      end
+
+      specify "renders the content before and after the meta item links" do
+        expect(rendered_content).to have_tag("div", with: { class: "govuk-footer__meta-item" }) do
+          with_text(/before/)
+          with_text(/after/)
+        end
+      end
+
+      specify "renders the content in the right order" do
+        expect(rendered_content).to have_tag(".govuk-footer__meta-item") { with_text(/before.*one.*two.*three.*after/m) }
+      end
+    end
+
     describe "custom meta_licence text" do
       let(:licence_text) { "Permission is hereby granted, free of charge, to any person obtaining a copy of this software" }
       let(:kwargs) { { meta_licence: licence_text } }


### PR DESCRIPTION
These slots don't have any functionality but allow arbitrary html to be placed before/after the meta links.

* [x] Update the template so unnecessary whitespace isn't added when the slots aren't used
* [x] Make the testing a bit more robust
