### PR TITLE
Update tabs component to have a default title

### DIFF
--- a/app/components/govuk_component/tab_component.html.erb
+++ b/app/components/govuk_component/tab_component.html.erb
@@ -1,5 +1,5 @@
 <%= tag.div(**html_attributes) do %>
-  <%= tag.h2(title, class: "#{brand}-tabs__title") %>
+  <%= tag.h2(title, class: "#{brand}-tabs__title") if title %>
   <ul class="<%= brand %>-tabs__list">
     <% tabs.each.with_index do |tab, i| %>
       <%= tag.li(tab.li_link, class: tab.li_classes(i)) %>

--- a/app/components/govuk_component/tab_component.rb
+++ b/app/components/govuk_component/tab_component.rb
@@ -5,7 +5,7 @@ class GovukComponent::TabComponent < GovukComponent::Base
 
   attr_reader :title, :id
 
-  def initialize(title:, id: nil, classes: [], html_attributes: {})
+  def initialize(title: 'Contents', id: nil, classes: [], html_attributes: {})
     @title = title
     @id    = id
 

--- a/guide/content/components/tabs.slim
+++ b/guide/content/components/tabs.slim
@@ -12,7 +12,7 @@ p
   render_in_boxes: true) do
 
   markdown:
-    The tabs component must be given a `title`, which is displayed above a list of jump links on narrow screens or if javascript is unavailable. This is usually set to ‘Contents’.
+    The tabs component have a `title`, which is displayed above a list of jump links on narrow screens or if javascript is unavailable. This defaults to ‘Contents’ but can be changed if needed.
 
     Each tab requires a `label` which will form the link at the top.
 

--- a/guide/lib/examples/tabs_helpers.rb
+++ b/guide/lib/examples/tabs_helpers.rb
@@ -2,7 +2,7 @@ module Examples
   module TabsHelpers
     def tabs_normal
       <<~TABS
-        = govuk_tabs(title: "Contents") do |tabs|
+        = govuk_tabs do |tabs|
           - tabs.with_tab(label: "Text", text: "This was set using a text argument")
           - tabs.with_tab(label: "Inline block") { "This was set using an inline block of content" }
           - tabs.with_tab(label: "Regular block") do

--- a/spec/components/govuk_component/tab_component_spec.rb
+++ b/spec/components/govuk_component/tab_component_spec.rb
@@ -106,6 +106,22 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
     end
   end
 
+  context 'when the title isn’t specified' do
+    subject { render_inline(GovukComponent::TabComponent.new) }
+
+    it 'should use the default title ‘Contents’' do
+      expect(rendered_content).to have_tag('.govuk-tabs__title', text: 'Contents')
+    end
+  end
+
+  context 'when the title is nil' do
+    subject { render_inline(GovukComponent::TabComponent.new(title: nil)) }
+
+    it 'should not contain a title' do
+      expect(rendered_content).not_to have_tag('.govuk-tabs__title')
+    end
+  end
+
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'


### PR DESCRIPTION
Set the default title to 'Contents' if not specified.

Fixes #507