### PR TITLE
Upgrade to GOV.UK Frontend 5.3.0

### DIFF
--- a/app/components/govuk_component/header_component.html.erb
+++ b/app/components/govuk_component/header_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.header(role: 'banner', data: { module: "#{brand}-header" }, **html_attributes) do %>
+<%= tag.header(data: { module: "#{brand}-header" }, **html_attributes) do %>
   <%= tag.div(**container_html_attributes) do %>
     <div class="<%= brand %>-header__logo">
       <%= link_to(homepage_url, class: ["#{brand}-header__link", "#{brand}-header__link--homepage"]) do %>

--- a/app/components/govuk_component/pagination_component.rb
+++ b/app/components/govuk_component/pagination_component.rb
@@ -85,7 +85,7 @@ class GovukComponent::PaginationComponent < GovukComponent::Base
 private
 
   def default_attributes
-    { role: "navigation", aria: { label: landmark_label }, class: "#{brand}-pagination" }
+    { aria: { label: landmark_label }, class: "#{brand}-pagination" }
   end
 
   def build_previous

--- a/guide/layouts/partials/footer.slim
+++ b/guide/layouts/partials/footer.slim
@@ -1,4 +1,4 @@
-footer.govuk-footer role="contentinfo"
+footer.govuk-footer
   .govuk-width-container
     .govuk-footer__meta
       .govuk-footer__meta-item.govuk-footer__meta-item--grow

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -11,7 +11,7 @@
       "license": "ISC",
       "dependencies": {
         "@x-govuk/govuk-prototype-components": "^3.0.0",
-        "govuk-frontend": "5.2.0",
+        "govuk-frontend": "5.3.0",
         "sass": "^1.52.1"
       }
     },
@@ -1687,9 +1687,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.2.0.tgz",
-      "integrity": "sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.3.0.tgz",
+      "integrity": "sha512-w6yaaDU3nqhVmWJFnOuJKRIUEB/2RrTFGzoA3z5n4cTG9h292EseT/q+JJA/LYTf5IYzeTIVAUbE5fFjUxefiQ==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/guide/package.json
+++ b/guide/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@x-govuk/govuk-prototype-components": "^3.0.0",
-    "govuk-frontend": "5.2.0",
+    "govuk-frontend": "5.3.0",
     "sass": "^1.52.1"
   }
 }


### PR DESCRIPTION
- **Upgrade to govuk-frontend 5.3.0**
- **Remove role attribute from header, footer and nav**
