### PR TITLE
Update list example

### DIFF
--- a/guide/lib/examples/list_helpers.rb
+++ b/guide/lib/examples/list_helpers.rb
@@ -14,7 +14,7 @@ module Examples
 
     def govuk_list_number
       <<~EXAMPLE
-        = govuk_list ["Delivery address.", "Payment.", "Confirmation."], type: :bullet
+        = govuk_list ["Delivery address.", "Payment.", "Confirmation."], type: :number
       EXAMPLE
     end
 


### PR DESCRIPTION
The example code for a numbered list included the `:bullet` tag instead of the `:number` one