### PR TITLE
Allow tabs to have set ids

### DIFF
--- a/app/components/govuk_component/tab_component.rb
+++ b/app/components/govuk_component/tab_component.rb
@@ -21,15 +21,16 @@ private
   class Tab < GovukComponent::Base
     attr_reader :label, :text
 
-    def initialize(label:, text: nil, classes: [], html_attributes: {})
+    def initialize(label:, text: nil, id: nil, classes: [], html_attributes: {})
       @label = label
       @text  = h(text)
+      @id    = id || label.parameterize
 
       super(classes:, html_attributes:)
     end
 
     def id(prefix: nil)
-      [prefix, label.parameterize].join
+      [prefix, @id].join
     end
 
     def hidden_class(i = nil)

--- a/spec/components/govuk_component/tab_component_spec.rb
+++ b/spec/components/govuk_component/tab_component_spec.rb
@@ -133,5 +133,27 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
 
     it_behaves_like 'a component with a slot that accepts custom classes'
     it_behaves_like 'a component with a slot that accepts custom html attributes'
+
+    context "when id is supplied" do
+      let(:id) { "some-id" }
+
+      subject! do
+        render_inline(described_class.send(:new, **kwargs)) do |component|
+          component.send("with_#{slot}", label: "id testination", id:) do
+            content.call
+          end
+        end
+      end
+
+      specify "the id is present in the rendered output" do
+        expect(rendered_content).to have_tag("div", with: { id: "some-id" })
+      end
+
+      specify "the link anchor uses the given id" do
+        expect(rendered_content).to have_tag("a", with: { href: "#some-id" }) do
+          with_text("id testination")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The tab id attribute is currently based on the label given the tab. In some cases, however, this label may be dynamic, e.g. if the label includes the number of records included in that tab. Having an id that changes this way can get in the way of testing or potentially other functionality that may depend on the id being static.