### PR TITLE
Allow default summary list value text to be configured

### DIFF
--- a/app/components/govuk_component/summary_list_component/value_component.rb
+++ b/app/components/govuk_component/summary_list_component/value_component.rb
@@ -18,6 +18,6 @@ private
   end
 
   def value_content
-    content || text || ""
+    content || text || config.default_summary_list_value_text
   end
 end

--- a/guide/content/components/summary-list.slim
+++ b/guide/content/components/summary-list.slim
@@ -43,7 +43,12 @@ p
   code: summary_list_with_missing_information) do
 
   markdown:
-    If a row has missing information, include a link to add the information within the value column instead of as an action.
+    If a row has missing information, include a link to add the information
+    within the value column instead of as an action.
+
+    When there is no link fallback text will be used. By default it's
+    a blank string but can be overridden by [configuring](/introduction/configuration/)
+    the `default_summary_list_value_text`.
 
 == render('/partials/example.*',
   caption: "Building a summary list directly from data",

--- a/lib/govuk/components/engine.rb
+++ b/lib/govuk/components/engine.rb
@@ -63,6 +63,7 @@ module Govuk
     # +:default_tag_colour+ the default colour for tags, possible values: +grey+, +green+, +turquoise+, +blue+, +red+, +purple+, +pink+, +orange+, +yellow+. Defaults to +nil+
     # +:default_start_button_as_button+ false
     # +:default_summary_list_borders+ true
+    # +:default_summary_list_value_text+ the fallback text for summary list values which will be displayed when the value is nil. Defaults to +""+
     # +:default_notification_banner_title_id+ "govuk-notification-banner-title"
     # +:default_notification_disable_auto_focus+ nil
     # +:default_notification_title_heading_level+ 2
@@ -104,6 +105,7 @@ module Govuk
       default_tag_colour: nil,
       default_start_button_as_button: false,
       default_summary_list_borders: true,
+      default_summary_list_value_text: "",
       default_notification_banner_title_id: "govuk-notification-banner-title",
       default_notification_disable_auto_focus: nil,
       default_notification_title_heading_level: 2,

--- a/spec/components/govuk_component/configuration/summary_list_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/summary_list_configuration_spec.rb
@@ -18,6 +18,27 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
       end
     end
 
+    describe 'default_summary_list_value_text' do
+      before do
+        Govuk::Components.configure do |config|
+          config.default_summary_list_value_text = "Nothing"
+        end
+      end
+
+      subject! do
+        render_inline(GovukComponent::SummaryListComponent.new) do |sl|
+          sl.with_row do |row|
+            row.with_key(text: "Key without value")
+            row.with_value(text: nil)
+          end
+        end
+      end
+
+      specify 'renders a value with the overridden default text' do
+        expect(rendered_content).to have_tag("dd", text: "Nothing", with: { class: "govuk-summary-list__value" })
+      end
+    end
+
     describe 'require_summary_list_action_visually_hidden_text' do
       before do
         Govuk::Components.configure do |config|


### PR DESCRIPTION
Being able to set the default fallback text for summary list values is convenient and saves people from peppering extra logic throughout the views.

The new configuration value, `default_summary_list_value_text`, defaults to `""` so the behaviour of the library won't change unexpectedly.

Fixes #411

### Final tasks

* [ ] add a paragraph (or maybe new section) to the guide explaining the behaviour and suggesting [better alternatives than fallback text](https://design-system.service.gov.uk/components/summary-list/#showing-missing-information) following @frankieroberto's suggestion
