### PR TITLE
Component specific branding

### DIFF
--- a/app/components/govuk_component/base.rb
+++ b/app/components/govuk_component/base.rb
@@ -27,6 +27,13 @@ class GovukComponent::Base < ViewComponent::Base
   end
 
   def brand(override = nil)
-    override || config.brand
+    override || config.brand_overrides.fetch(class_prefix, config.brand)
+  end
+
+  # We want the main component and the subcomponents here so
+  # match on the second segment of the component class name
+  def class_prefix
+    # FIXME: this looks a bit dodgy...
+    self.class.name.match(/\w+::\w+/).to_s
   end
 end

--- a/lib/govuk/components/engine.rb
+++ b/lib/govuk/components/engine.rb
@@ -91,6 +91,7 @@ module Govuk
         # 'GovukComponent::PanelComponent'               => 'another-brand',
         # 'GovukComponent::PhaseBannerComponent'         => 'another-brand',
         # 'GovukComponent::SectionBreakComponent'        => 'another-brand',
+        # 'GovukComponent::ServiceNavigationComponent'   => 'another-brand',
         # 'GovukComponent::StartButtonComponent'         => 'another-brand',
         # 'GovukComponent::SummaryListComponent'         => 'another-brand',
         # 'GovukComponent::TableComponent'               => 'another-brand',

--- a/lib/govuk/components/engine.rb
+++ b/lib/govuk/components/engine.rb
@@ -33,6 +33,7 @@ module Govuk
     # Default components configuration
     #
     # +:brand+ sets the value used to prefix all classes, used to allow the components to be branded for alternative (similar) design systems
+    # +:brand_overrides+ sets the value used to prefix classes and slots for the component class.
     # +:default_back_link_text+ Default text for the back link, defaults to +Back+
     # +:default_breadcrumbs_collapse_on_mobile+ false
     # +:default_breadcrumbs_hide_in_print+ false
@@ -75,6 +76,29 @@ module Govuk
     # +:enable_auto_table_scopes+ automatically adds a scope of 'col' to th elements in thead and 'row' to th elements in tbody.
     DEFAULTS = {
       brand: 'govuk',
+      brand_overrides: {
+        # 'GovukComponent::AccordionComponent'           => 'another-brand',
+        # 'GovukComponent::BackLinkComponent'            => 'another-brand',
+        # 'GovukComponent::BreadcrumbsComponent'         => 'another-brand',
+        # 'GovukComponent::CookieBannerComponent'        => 'another-brand',
+        # 'GovukComponent::DetailsComponent'             => 'another-brand',
+        # 'GovukComponent::ExitThisPageComponent'        => 'another-brand',
+        # 'GovukComponent::FooterComponent'              => 'another-brand',
+        # 'GovukComponent::HeaderComponent'              => 'another-brand',
+        # 'GovukComponent::InsetTextComponent'           => 'another-brand',
+        # 'GovukComponent::NotificationBannerComponent'  => 'another-brand',
+        # 'GovukComponent::PaginationComponent'          => 'another-brand',
+        # 'GovukComponent::PanelComponent'               => 'another-brand',
+        # 'GovukComponent::PhaseBannerComponent'         => 'another-brand',
+        # 'GovukComponent::SectionBreakComponent'        => 'another-brand',
+        # 'GovukComponent::StartButtonComponent'         => 'another-brand',
+        # 'GovukComponent::SummaryListComponent'         => 'another-brand',
+        # 'GovukComponent::TableComponent'               => 'another-brand',
+        # 'GovukComponent::TabComponent'                 => 'another-brand',
+        # 'GovukComponent::TagComponent'                 => 'another-brand',
+        # 'GovukComponent::TaskListComponent'            => 'another-brand',
+        # 'GovukComponent::WarningTextComponent'         => 'another-brand',
+      },
       default_back_link_text: 'Back',
       default_breadcrumbs_collapse_on_mobile: false,
       default_breadcrumbs_hide_in_print: false,

--- a/spec/components/govuk_component/accordion_component_spec.rb
+++ b/spec/components/govuk_component/accordion_component_spec.rb
@@ -194,6 +194,7 @@ RSpec.describe(GovukComponent::AccordionComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 
   context 'slot arguments' do
     let(:slot) { :section }

--- a/spec/components/govuk_component/back_link_component_spec.rb
+++ b/spec/components/govuk_component/back_link_component_spec.rb
@@ -49,4 +49,5 @@ RSpec.describe(GovukComponent::BackLinkComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 end

--- a/spec/components/govuk_component/breadcrumbs_component_spec.rb
+++ b/spec/components/govuk_component/breadcrumbs_component_spec.rb
@@ -89,4 +89,5 @@ RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 end

--- a/spec/components/govuk_component/cookie_banner_component_spec.rb
+++ b/spec/components/govuk_component/cookie_banner_component_spec.rb
@@ -106,6 +106,9 @@ RSpec.describe(GovukComponent::CookieBannerComponent::MessageComponent, type: :c
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides' do
+    let(:component_class_name) { "GovukComponent::CookieBannerComponent" }
+  end
 
   context "when there is no text or block" do
     specify "raises an appropriate error" do

--- a/spec/components/govuk_component/details_component_spec.rb
+++ b/spec/components/govuk_component/details_component_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe(GovukComponent::DetailsComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 
   context 'when text is supplied' do
     before { render_inline(described_class.new(**kwargs)) }

--- a/spec/components/govuk_component/exit_this_page_component_spec.rb
+++ b/spec/components/govuk_component/exit_this_page_component_spec.rb
@@ -114,4 +114,5 @@ RSpec.describe(GovukComponent::ExitThisPageComponent, type: :component) do
   end
 
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 end

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -282,6 +282,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 
   describe "navigation" do
     let(:custom_text) { "Some meta html" }

--- a/spec/components/govuk_component/header_component_spec.rb
+++ b/spec/components/govuk_component/header_component_spec.rb
@@ -319,6 +319,7 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 
   context 'slot arguments' do
     let(:slot) { :navigation_item }

--- a/spec/components/govuk_component/inset_text_component_spec.rb
+++ b/spec/components/govuk_component/inset_text_component_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe(GovukComponent::InsetTextComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 
   context 'when text is supplied' do
     before { render_inline(described_class.new(**kwargs)) }

--- a/spec/components/govuk_component/notification_banner_component_spec.rb
+++ b/spec/components/govuk_component/notification_banner_component_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
       let(:kwargs) { { title_text: title, text: "something", title_id: 'custom-id' } }
 
       it_behaves_like 'a component that supports custom branding'
+      it_behaves_like 'a component that supports brand overrides'
     end
 
     context "when supplied with a block" do

--- a/spec/components/govuk_component/pagination_component_spec.rb
+++ b/spec/components/govuk_component/pagination_component_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe(GovukComponent::PaginationComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 
   specify "renders some page items" do
     expect(rendered_content).to have_tag("nav", with: { class: component_css_class }) do

--- a/spec/components/govuk_component/panel_component_spec.rb
+++ b/spec/components/govuk_component/panel_component_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 
   specify 'contains a panel with the correct title and text' do
     render_inline(described_class.new(**kwargs))

--- a/spec/components/govuk_component/phase_banner_component_spec.rb
+++ b/spec/components/govuk_component/phase_banner_component_spec.rb
@@ -46,4 +46,7 @@ RSpec.describe(GovukComponent::PhaseBannerComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides' do
+    let(:extra_overrides) { ["GovukComponent::TagComponent"] }
+  end
 end

--- a/spec/components/govuk_component/section_break_component_spec.rb
+++ b/spec/components/govuk_component/section_break_component_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe GovukComponent::SectionBreakComponent, type: :component do
   it_behaves_like "a component that accepts custom classes"
   it_behaves_like "a component that accepts custom HTML attributes"
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 
   context "when visible is true" do
     it "renders the section break with the visible class" do

--- a/spec/components/govuk_component/service_navigation_component_spec.rb
+++ b/spec/components/govuk_component/service_navigation_component_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe(GovukComponent::ServiceNavigationComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 
   specify 'renders a div with the expected attributes' do
     expect(rendered_content).to have_tag("div", with: { class: component_css_class, 'data-module' => 'govuk-service-navigation' })

--- a/spec/components/govuk_component/start_button_component_spec.rb
+++ b/spec/components/govuk_component/start_button_component_spec.rb
@@ -67,5 +67,6 @@ RSpec.describe(GovukComponent::StartButtonComponent, type: :component) do
     it_behaves_like 'a component that accepts custom classes'
     it_behaves_like 'a component that accepts custom HTML attributes'
     it_behaves_like 'a component that supports custom branding'
+    it_behaves_like 'a component that supports brand overrides'
   end
 end

--- a/spec/components/govuk_component/summary_list_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_component_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 
   subject! do
     render_inline(described_class.new(**kwargs)) do |component|

--- a/spec/components/govuk_component/tab_component_spec.rb
+++ b/spec/components/govuk_component/tab_component_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 
   context 'slot arguments' do
     let(:slot) { :tab }

--- a/spec/components/govuk_component/table_component_spec.rb
+++ b/spec/components/govuk_component/table_component_spec.rb
@@ -498,6 +498,7 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 
   describe "column groups and columns" do
     subject! do

--- a/spec/components/govuk_component/tag_component_spec.rb
+++ b/spec/components/govuk_component/tag_component_spec.rb
@@ -70,4 +70,7 @@ RSpec.describe(GovukComponent::TagComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides' do
+    let(:component_class) { "GovukComponent::TagComponent" }
+  end
 end

--- a/spec/components/govuk_component/task_list_component_spec.rb
+++ b/spec/components/govuk_component/task_list_component_spec.rb
@@ -372,4 +372,5 @@ RSpec.describe(GovukComponent::TaskListComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 end

--- a/spec/components/govuk_component/warning_text_component_spec.rb
+++ b/spec/components/govuk_component/warning_text_component_spec.rb
@@ -74,4 +74,5 @@ RSpec.describe(GovukComponent::WarningTextComponent, type: :component) do
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
   it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
 end

--- a/spec/components/shared/a_component_that_supports_custom_branding.rb
+++ b/spec/components/shared/a_component_that_supports_custom_branding.rb
@@ -24,3 +24,37 @@ shared_examples 'a component that supports custom branding' do
     expect(rendered_content).not_to match(Regexp.new(default_brand))
   end
 end
+
+shared_examples 'a component that supports brand overrides' do
+  let(:default_brand) { 'govuk' }
+  let(:custom_brand) { 'carrington-institute' }
+
+  before do
+    class_name = defined?(component_class_name) ? component_class_name : described_class.name
+    extra_classes = if defined?(extra_overrides)
+                      extra_overrides.index_with(custom_brand)
+                    else
+                      {}
+                    end
+
+    Govuk::Components.configure do |conf|
+      conf.brand_overrides = { class_name => custom_brand, **extra_classes }
+    end
+  end
+
+  after do
+    Govuk::Components.reset!
+  end
+
+  specify "should contain the custom branding" do
+    render_inline(described_class.new(**kwargs))
+
+    expect(rendered_content).to match(Regexp.new(custom_brand))
+  end
+
+  specify "should not contain any default branding" do
+    render_inline(described_class.new(**kwargs))
+
+    expect(rendered_content).not_to match(Regexp.new(default_brand))
+  end
+end

--- a/spec/components/shared/a_component_that_supports_custom_branding.rb
+++ b/spec/components/shared/a_component_that_supports_custom_branding.rb
@@ -31,11 +31,7 @@ shared_examples 'a component that supports brand overrides' do
 
   before do
     class_name = defined?(component_class_name) ? component_class_name : described_class.name
-    extra_classes = if defined?(extra_overrides)
-                      extra_overrides.index_with(custom_brand)
-                    else
-                      {}
-                    end
+    extra_classes = defined?(extra_overrides) ? extra_overrides.index_with(custom_brand) : {}
 
     Govuk::Components.configure do |conf|
       conf.brand_overrides = { class_name => custom_brand, **extra_classes }


### PR DESCRIPTION
There are some components in the GOV.UK Design System that don't appear in the NHS design system. Currently teams who want to use these components need to manually copy and adjust chunks of SCSS, replacing `govuk` for `nhsuk` - a laborious process.

We can make this a little easier by allowing the brand to be configured on a component-by-component basis, reducing the amount of custom styles needed.

The reason this approach was taken and not just passing in a `brand` override to each component is that there's no easy way of passing arguments through to the slots without [converting them all to lambdas](https://viewcomponent.org/guide/slots.html#lambda-slots).

This will likely be a really niche feature.

Fixes #547 
