### PR TITLE
Service navigation

### DIFF
--- a/app/components/govuk_component/header_component.rb
+++ b/app/components/govuk_component/header_component.rb
@@ -9,7 +9,8 @@ class GovukComponent::HeaderComponent < GovukComponent::Base
               :menu_button_label,
               :navigation_label,
               :custom_navigation_classes,
-              :custom_container_classes
+              :custom_container_classes,
+              :full_width_border
 
   def initialize(classes: [],
                  html_attributes: {},
@@ -19,7 +20,8 @@ class GovukComponent::HeaderComponent < GovukComponent::Base
                  navigation_label: config.default_header_navigation_label,
                  service_name: config.default_header_service_name,
                  service_url: config.default_header_service_url,
-                 container_classes: nil)
+                 container_classes: nil,
+                 full_width_border: false)
 
     @homepage_url              = homepage_url
     @service_name              = service_name
@@ -28,6 +30,7 @@ class GovukComponent::HeaderComponent < GovukComponent::Base
     @custom_navigation_classes = navigation_classes
     @navigation_label          = navigation_label
     @custom_container_classes  = container_classes
+    @full_width_border         = full_width_border
 
     super(classes:, html_attributes:)
   end
@@ -35,7 +38,12 @@ class GovukComponent::HeaderComponent < GovukComponent::Base
 private
 
   def default_attributes
-    { class: ["#{brand}-header"] }
+    {
+      class: class_names(
+        "#{brand}-header",
+        "#{brand}-header--full-width-border" => full_width_border
+      )
+    }
   end
 
   def navigation_html_attributes

--- a/app/components/govuk_component/service_navigation_component.rb
+++ b/app/components/govuk_component/service_navigation_component.rb
@@ -1,0 +1,81 @@
+class GovukComponent::ServiceNavigationComponent < GovukComponent::Base
+  renders_one :service_name, "GovukComponent::ServiceNavigationComponent::ServiceNameComponent"
+  renders_many :navigation_items, ->(text:, href: nil, current_path: nil, active_when: nil, current: false, active: false, classes: [], html_attributes: {}) do
+    GovukComponent::ServiceNavigationComponent::NavigationItemComponent.new(
+      text:,
+      href:,
+      current_path:,
+      active_when:,
+      current:,
+      active:,
+      classes:,
+      html_attributes:
+    )
+  end
+
+  attr_reader :aria_label_text
+
+  def initialize(service_name: nil, service_url: nil, navigation_items: [], current_path: nil, aria_label: "Service information", classes: [], html_attributes: {})
+    @service_name_text = service_name
+    @service_url = service_url
+    @current_path = current_path
+    @aria_label_text = aria_label
+
+    if @service_name_text.present?
+      with_service_name(service_name: @service_name_text, service_url:)
+    end
+
+    navigation_items.each { |ni| with_navigation_item(current_path:, **ni) }
+
+    super(classes:, html_attributes:)
+  end
+
+  def call
+    outer_element do
+      tag.div(class: 'govuk-width_container') do
+        tag.div(class: 'govuk-service-navigation__container') do
+          safe_join([service_name, navigation].compact)
+        end
+      end
+    end
+  end
+
+  def navigation
+    return unless navigation_items?
+
+    tag.nav(aria: { label: "Menu" }, class: 'govuk-service-navigation__wrapper') do
+      safe_join([menu_button, navigation_list])
+    end
+  end
+
+  def navigation_list
+    tag.ul(safe_join(navigation_items), class: 'govuk-service-navigation__list')
+  end
+
+private
+
+  def outer_element(&block)
+    if service_name?
+      tag.section(**aria_attributes, **html_attributes, &block)
+    else
+      tag.div(**html_attributes, &block)
+    end
+  end
+
+  def default_attributes
+    { class: 'govuk-service-navigation', data: { module: 'govuk-service-navigation' } }
+  end
+
+  def aria_attributes
+    { aria: { label: aria_label_text } }
+  end
+
+  def menu_button
+    tag.button(
+      type: 'button',
+      class: %w(govuk-service-navigation__toggle govuk-js-service-navigation-toggle),
+      aria: { controls: 'navigation' },
+      hidden: true
+    )
+  end
+end

--- a/app/components/govuk_component/service_navigation_component.rb
+++ b/app/components/govuk_component/service_navigation_component.rb
@@ -32,8 +32,8 @@ class GovukComponent::ServiceNavigationComponent < GovukComponent::Base
 
   def call
     outer_element do
-      tag.div(class: 'govuk-width_container') do
-        tag.div(class: 'govuk-service-navigation__container') do
+      tag.div(class: "#{brand}-width_container") do
+        tag.div(class: "#{brand}-service-navigation__container") do
           safe_join([service_name, navigation].compact)
         end
       end
@@ -43,13 +43,13 @@ class GovukComponent::ServiceNavigationComponent < GovukComponent::Base
   def navigation
     return unless navigation_items?
 
-    tag.nav(aria: { label: "Menu" }, class: 'govuk-service-navigation__wrapper') do
+    tag.nav(aria: { label: "Menu" }, class: "#{brand}-service-navigation__wrapper") do
       safe_join([menu_button, navigation_list])
     end
   end
 
   def navigation_list
-    tag.ul(safe_join(navigation_items), class: 'govuk-service-navigation__list')
+    tag.ul(safe_join(navigation_items), class: "#{brand}-service-navigation__list")
   end
 
 private
@@ -63,7 +63,7 @@ private
   end
 
   def default_attributes
-    { class: 'govuk-service-navigation', data: { module: 'govuk-service-navigation' } }
+    { class: "#{brand}-service-navigation", data: { module: "#{brand}-service-navigation" } }
   end
 
   def aria_attributes
@@ -73,7 +73,7 @@ private
   def menu_button
     tag.button(
       type: 'button',
-      class: %w(govuk-service-navigation__toggle govuk-js-service-navigation-toggle),
+      class: ["#{brand}-service-navigation__toggle", "#{brand}-js-service-navigation-toggle"],
       aria: { controls: 'navigation' },
       hidden: true
     )

--- a/app/components/govuk_component/service_navigation_component/navigation_item_component.rb
+++ b/app/components/govuk_component/service_navigation_component/navigation_item_component.rb
@@ -16,9 +16,9 @@ class GovukComponent::ServiceNavigationComponent::NavigationItemComponent < Govu
   def call
     tag.li(**html_attributes) do
       if href.present?
-        wrap_link(link_to(text, href, class: 'govuk-service-navigation__link', **aria_current))
+        wrap_link(link_to(text, href, class: "#{brand}-service-navigation__link", **aria_current))
       else
-        tag.span(text, class: 'govuk-service-navigation__text')
+        tag.span(text, class: "#{brand}-service-navigation__text")
       end
     end
   end
@@ -27,7 +27,7 @@ private
 
   def wrap_link(link)
     if current_or_active?
-      tag.strong(link, class: 'govuk-service-navigation__active-fallback')
+      tag.strong(link, class: "#{brand}-service-navigation__active-fallback")
     else
       link
     end
@@ -69,8 +69,8 @@ private
   def default_attributes
     {
       class: class_names(
-        'govuk-service-navigation__item',
-        'govuk-service-navigation__item--active' => current_or_active?
+        "#{brand}-service-navigation__item",
+        "#{brand}-service-navigation__item--active" => current_or_active?
       )
     }
   end

--- a/app/components/govuk_component/service_navigation_component/navigation_item_component.rb
+++ b/app/components/govuk_component/service_navigation_component/navigation_item_component.rb
@@ -1,0 +1,83 @@
+class GovukComponent::ServiceNavigationComponent::NavigationItemComponent < GovukComponent::Base
+  attr_reader :text, :href, :current_path, :active_when, :current, :active
+
+  def initialize(text:, href: nil, current_path: nil, active_when: nil, current: false, active: false, classes: [], html_attributes: {})
+    @current = current
+    @active = active
+    @text = text
+    @href = href
+
+    @current_path = current_path
+    @active_when = active_when
+
+    super(classes:, html_attributes:)
+  end
+
+  def call
+    tag.li(**html_attributes) do
+      if href.present?
+        wrap_link(link_to(text, href, class: 'govuk-service-navigation__link', **aria_current))
+      else
+        tag.span(text, class: 'govuk-service-navigation__text')
+      end
+    end
+  end
+
+private
+
+  def wrap_link(link)
+    if current_or_active?
+      tag.strong(link, class: 'govuk-service-navigation__active-fallback')
+    else
+      link
+    end
+  end
+
+  def current?
+    current || auto_current?
+  end
+
+  def active?
+    active || auto_active?
+  end
+
+  def current_or_active?
+    current? || active?
+  end
+
+  def auto_current?
+    return if current_path.blank?
+
+    current_path == href
+  end
+
+  def auto_active?
+    return if current_path.blank?
+
+    case active_when
+    when Regexp
+      active_when.match?(current_path)
+    when String
+      current_path.start_with?(active_when)
+    when Array
+      active_when.any? { |p| current_path.start_with?(p) }
+    else
+      false
+    end
+  end
+
+  def default_attributes
+    {
+      class: class_names(
+        'govuk-service-navigation__item',
+        'govuk-service-navigation__item--active' => current_or_active?
+      )
+    }
+  end
+
+  def aria_current
+    current = (current?) ? 'page' : true
+
+    { aria: { current: } }
+  end
+end

--- a/app/components/govuk_component/service_navigation_component/service_name_component.rb
+++ b/app/components/govuk_component/service_navigation_component/service_name_component.rb
@@ -1,7 +1,7 @@
 class GovukComponent::ServiceNavigationComponent::ServiceNameComponent < GovukComponent::Base
   attr_reader :service_name, :service_url
 
-  def initialize(service_name:, service_url:, classes: [], html_attributes: {})
+  def initialize(service_name:, service_url: nil, classes: [], html_attributes: {})
     @service_name = service_name
     @service_url = service_url
 

--- a/app/components/govuk_component/service_navigation_component/service_name_component.rb
+++ b/app/components/govuk_component/service_navigation_component/service_name_component.rb
@@ -1,0 +1,30 @@
+class GovukComponent::ServiceNavigationComponent::ServiceNameComponent < GovukComponent::Base
+  attr_reader :service_name, :service_url
+
+  def initialize(service_name:, service_url:, classes: [], html_attributes: {})
+    @service_name = service_name
+    @service_url = service_url
+
+    super(classes:, html_attributes:)
+  end
+
+  def call
+    text = (service_url.present?) ? build_link : build_span
+
+    tag.span(text, **html_attributes)
+  end
+
+private
+
+  def build_link
+    link_to(service_name, service_url, class: 'govuk-service-navigation__link')
+  end
+
+  def build_span
+    tag.span(service_name, class: 'govuk-service-navigation__text')
+  end
+
+  def default_attributes
+    { class: 'govuk-service-navigation__service-name' }
+  end
+end

--- a/app/components/govuk_component/service_navigation_component/service_name_component.rb
+++ b/app/components/govuk_component/service_navigation_component/service_name_component.rb
@@ -17,14 +17,14 @@ class GovukComponent::ServiceNavigationComponent::ServiceNameComponent < GovukCo
 private
 
   def build_link
-    link_to(service_name, service_url, class: 'govuk-service-navigation__link')
+    link_to(service_name, service_url, class: "#{brand}-service-navigation__link")
   end
 
   def build_span
-    tag.span(service_name, class: 'govuk-service-navigation__text')
+    tag.span(service_name, class: "#{brand}-service-navigation__text")
   end
 
   def default_attributes
-    { class: 'govuk-service-navigation__service-name' }
+    { class: "#{brand}-service-navigation__service-name" }
   end
 end

--- a/app/helpers/govuk_components_helper.rb
+++ b/app/helpers/govuk_components_helper.rb
@@ -13,6 +13,7 @@ module GovukComponentsHelper
     govuk_pagination: 'GovukComponent::PaginationComponent',
     govuk_panel: 'GovukComponent::PanelComponent',
     govuk_phase_banner: 'GovukComponent::PhaseBannerComponent',
+    govuk_service_navigation: 'GovukComponent::ServiceNavigationComponent',
     govuk_section_break: 'GovukComponent::SectionBreakComponent',
     govuk_start_button: 'GovukComponent::StartButtonComponent',
     govuk_summary_list: 'GovukComponent::SummaryListComponent',

--- a/guide/content/components/service-navigation.slim
+++ b/guide/content/components/service-navigation.slim
@@ -7,7 +7,7 @@ p
     and lets them navigate around your service.
 
 == render('/partials/example.*',
-  caption: "Service navigation with only a service name",
+  caption: "With only a service name",
   code: service_navigation_with_only_service_name) do
 
   markdown:
@@ -16,13 +16,17 @@ p
     services this means the service navigation can be rendered without any navigation links.
 
 == render('/partials/example.*',
-  caption: "Service navigation with navigation items",
+  caption: "With navigation items",
   code: service_navigation_with_a_current_page,
   data: service_navigation_with_a_current_page_data) do
 
   markdown:
     Show navigation links to let users navigate to different parts of your
     service and find useful links and tools.
+
+    When you are on the linked page you can use `current: true` to mark it. If
+    you're on a page within the section but not on the page itself, use
+    `active: true` instead.
 
 == render('/partials/example.*',
   caption: "Automatically detecting the current page",
@@ -36,7 +40,7 @@ p
     the current page.
 
 == render('/partials/example.*',
-  caption: "Service navigation with automatic active page matching",
+  caption: "Automatic active page matching",
   code: service_navigation_with_matching_subpages,
   data: service_navigation_with_matching_subpages_data) do
 
@@ -48,5 +52,15 @@ p
     When `active_when` is a string the component will check if the beginning of
     the `current_path` matches it. For more complex scenarios a regular expression
     can be used instead.
+
+== render('/partials/example.*',
+  caption: "Manaully building the service navigation",
+  code: service_navigation_manual) do
+
+  markdown:
+    For extra customisation the service navigation can be assembled manually. We can
+    use the `start_slot` and `end_slot` to add custom HTML at the beginning and
+    end of the service navigation. This content needs its own custom styling or it will
+    be rendered above and below the other content.
 
 == render('/partials/related-navigation.*', links: service_navigation_info)

--- a/guide/content/components/service-navigation.slim
+++ b/guide/content/components/service-navigation.slim
@@ -1,0 +1,11 @@
+---
+title: Service navigation
+---
+
+== render('/partials/example.*',
+  caption: "Service navigation with only a service name",
+  code: service_navigation_with_only_service_name)
+
+== render('/partials/example.*',
+  caption: "Service navigation with navigation items",
+  code: service_navigation_with_navigation_items)

--- a/guide/content/components/service-navigation.slim
+++ b/guide/content/components/service-navigation.slim
@@ -2,10 +2,51 @@
 title: Service navigation
 ---
 
+p
+  | Service navigation helps users understand that they’re using your service
+    and lets them navigate around your service.
+
 == render('/partials/example.*',
   caption: "Service navigation with only a service name",
-  code: service_navigation_with_only_service_name)
+  code: service_navigation_with_only_service_name) do
+
+  markdown:
+    The Design System recommendation is [to display the service name in
+    the service navigation instead of in the header](https://design-system.service.gov.uk/components/service-navigation/#showing-your-service-name-only). On basic
+    services this means the service navigation can be rendered without any navigation links.
 
 == render('/partials/example.*',
   caption: "Service navigation with navigation items",
-  code: service_navigation_with_navigation_items)
+  code: service_navigation_with_a_current_page,
+  data: service_navigation_with_a_current_page_data) do
+
+  markdown:
+    Show navigation links to let users navigate to different parts of your
+    service and find useful links and tools.
+
+== render('/partials/example.*',
+  caption: "Automatically detecting the current page",
+  code: service_navigation_with_navigation_items,
+  data: service_navigation_with_navigation_items_data) do
+
+  markdown:
+    Having to work out which page is current and adjust the parameters manually
+    would be complicated. If you pass in the `current_path`, when navigation
+    nodes that have a matching `href` are rendered, they'll be rendered as
+    the current page.
+
+== render('/partials/example.*',
+  caption: "Service navigation with automatic active page matching",
+  code: service_navigation_with_matching_subpages,
+  data: service_navigation_with_matching_subpages_data) do
+
+  markdown:
+    Often we have pages deeply nested within sections of the site and want
+    the navigation to show which section we're currently in. We can do this
+    using `active_when`.
+
+    When `active_when` is a string the component will check if the beginning of
+    the `current_path` matches it. For more complex scenarios a regular expression
+    can be used instead.
+
+== render('/partials/related-navigation.*', links: service_navigation_info)

--- a/guide/content/stylesheets/application.scss
+++ b/guide/content/stylesheets/application.scss
@@ -91,3 +91,10 @@ $govuk-page-width: 1100px;
   color: tomato;
   font-weight: bold;
 }
+
+// Manual service navigation
+.app-service-navigation .govuk-width_container {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+}

--- a/guide/lib/examples/service_navigation_helpers.rb
+++ b/guide/lib/examples/service_navigation_helpers.rb
@@ -9,7 +9,8 @@ module Examples
     def service_navigation_with_a_current_page
       <<~SNIPPET
         = govuk_service_navigation(service_name: "My new service",
-                                   navigation_items: navigation_items)
+                                   navigation_items: navigation_items,
+                                   navigation_id: 'example-2')
       SNIPPET
     end
 
@@ -19,7 +20,8 @@ module Examples
           { text: "Footer",   href: "/components/footer" },
           { text: "Header",   href: "/components/header", current: true },
           { text: "Panel", href: "/components/panel" },
-          { text: "Table", href: "/components/table" }
+          { text: "Table", href: "/components/table" },
+          { text: "Tag",  href: "/components/tag" }
         ] }
       DATA
     end
@@ -28,7 +30,8 @@ module Examples
       <<~SNIPPET
         = govuk_service_navigation(service_name: "My new service",
                                    current_path: "/components/panel",
-                                   navigation_items: navigation_items)
+                                   navigation_items: navigation_items,
+                                   navigation_id: 'example-3')
       SNIPPET
     end
 
@@ -38,7 +41,8 @@ module Examples
           { text: "Footer",   href: "/components/footer" },
           { text: "Header",   href: "/components/header" },
           { text: "Panel", href: "/components/panel" },
-          { text: "Table",  href: "/components/table" }
+          { text: "Table",  href: "/components/table" },
+          { text: "Tag",  href: "/components/tag" }
         ] }
       DATA
     end
@@ -47,7 +51,8 @@ module Examples
       <<~SNIPPET
         = govuk_service_navigation(service_name: "My new service",
                                    current_path: "/components/table/dining/extendable",
-                                   navigation_items: navigation_items)
+                                   navigation_items: navigation_items,
+                                   navigation_id: 'example-4')
       SNIPPET
     end
 
@@ -57,9 +62,24 @@ module Examples
           { text: "Footer",   href: "/components/footer", active_when: "/components/footer" },
           { text: "Header",   href: "/components/header", active_when: "/components/header" },
           { text: "Panel", href: "/components/panel", active_when: "/components/panel" },
-          { text: "Table",  href: "/components/table", active_when: "/components/table" }
+          { text: "Table",  href: "/components/table", active_when: "/components/table" },
+          { text: "Tag",  href: "/components/tag", active_when: "/components/tag" }
         ] }
       DATA
+    end
+
+    def service_navigation_manual
+      <<~SNIPPET
+        = govuk_service_navigation(navigation_id: 'example-5', classes: 'app-service-navigation') do |sn|
+          = sn.with_start_slot { '🌅' }
+          = sn.with_service_name(service_name: 'A really great service', service_url: '#')
+          = sn.with_navigation_item(text: "Footer", href: "/components/footer")
+          = sn.with_navigation_item(text: "Header", href: "/components/header")
+          = sn.with_navigation_item(text: "Panel", href: "/components/panel")
+          = sn.with_navigation_item(text: "Table", href: "/components/table")
+          = sn.with_navigation_item(text: "Tag", href: "/components/tag", active: true)
+          = sn.with_end_slot { '🌆' }
+      SNIPPET
     end
   end
 end

--- a/guide/lib/examples/service_navigation_helpers.rb
+++ b/guide/lib/examples/service_navigation_helpers.rb
@@ -2,15 +2,64 @@ module Examples
   module ServiceNavigationHelpers
     def service_navigation_with_only_service_name
       <<~SNIPPET
-        = govuk_service_navigation(service_name: "My new service")
+        = govuk_service_navigation(service_name: "My new service", service_url: "#")
       SNIPPET
+    end
+
+    def service_navigation_with_a_current_page
+      <<~SNIPPET
+        = govuk_service_navigation(service_name: "My new service",
+                                   navigation_items: navigation_items)
+      SNIPPET
+    end
+
+    def service_navigation_with_a_current_page_data
+      <<~DATA
+        { navigation_items: [
+          { text: "Footer",   href: "/components/footer" },
+          { text: "Header",   href: "/components/header", current: true },
+          { text: "Panel", href: "/components/panel" },
+          { text: "Table", href: "/components/table" }
+        ] }
+      DATA
     end
 
     def service_navigation_with_navigation_items
       <<~SNIPPET
         = govuk_service_navigation(service_name: "My new service",
-                                   navigation_items: [ { text: "One" }, { text: "Two" } ])
+                                   current_path: "/components/panel",
+                                   navigation_items: navigation_items)
       SNIPPET
+    end
+
+    def service_navigation_with_navigation_items_data
+      <<~DATA
+        { navigation_items: [
+          { text: "Footer",   href: "/components/footer" },
+          { text: "Header",   href: "/components/header" },
+          { text: "Panel", href: "/components/panel" },
+          { text: "Table",  href: "/components/table" }
+        ] }
+      DATA
+    end
+
+    def service_navigation_with_matching_subpages
+      <<~SNIPPET
+        = govuk_service_navigation(service_name: "My new service",
+                                   current_path: "/components/table/dining/extendable",
+                                   navigation_items: navigation_items)
+      SNIPPET
+    end
+
+    def service_navigation_with_matching_subpages_data
+      <<~DATA
+        { navigation_items: [
+          { text: "Footer",   href: "/components/footer", active_when: "/components/footer" },
+          { text: "Header",   href: "/components/header", active_when: "/components/header" },
+          { text: "Panel", href: "/components/panel", active_when: "/components/panel" },
+          { text: "Table",  href: "/components/table", active_when: "/components/table" }
+        ] }
+      DATA
     end
   end
 end

--- a/guide/lib/examples/service_navigation_helpers.rb
+++ b/guide/lib/examples/service_navigation_helpers.rb
@@ -1,0 +1,16 @@
+module Examples
+  module ServiceNavigationHelpers
+    def service_navigation_with_only_service_name
+      <<~SNIPPET
+        = govuk_service_navigation(service_name: "My new service")
+      SNIPPET
+    end
+
+    def service_navigation_with_navigation_items
+      <<~SNIPPET
+        = govuk_service_navigation(service_name: "My new service",
+                                   navigation_items: [ { text: "One" }, { text: "Two" } ])
+      SNIPPET
+    end
+  end
+end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -63,6 +63,9 @@ require 'components/govuk_component/pagination_component/previous_page'
 require 'components/govuk_component/panel_component'
 require 'components/govuk_component/phase_banner_component'
 require 'components/govuk_component/section_break_component'
+require 'components/govuk_component/service_navigation_component'
+require 'components/govuk_component/service_navigation_component/navigation_item_component'
+require 'components/govuk_component/service_navigation_component/service_name_component'
 require 'components/govuk_component/start_button_component'
 require 'components/govuk_component/summary_list_component'
 require 'components/govuk_component/summary_list_component/key_component'
@@ -106,6 +109,7 @@ use_helper Examples::PaginationHelpers
 use_helper Examples::PanelHelpers
 use_helper Examples::PhaseBannerHelpers
 use_helper Examples::SectionBreakHelpers
+use_helper Examples::ServiceNavigationHelpers
 use_helper Examples::SkipLinkHelpers
 use_helper Examples::StartButtonHelpers
 use_helper Examples::SummaryListHelpers

--- a/guide/lib/helpers/content_helpers.rb
+++ b/guide/lib/helpers/content_helpers.rb
@@ -113,6 +113,12 @@ module Helpers
       }
     end
 
+    def service_navigation_info
+      {
+        "GOV.UK Design System service navigation documentation" => "https://design-system.service.gov.uk/components/service-navigation/"
+      }
+    end
+
   private
 
     def component_helper_mapping

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -39,6 +39,7 @@ module Helpers
           "Pagination" => "/components/pagination/",
           "Panel" => "/components/panel/",
           "Phase banner" => "/components/phase-banner/",
+          "Service navigation" => "/components/service-navigation/",
           "Start button" => "/components/start-button/",
           "Summary list" => "/components/summary-list/",
           "Table" => "/components/table/",

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -11,7 +11,7 @@
       "license": "ISC",
       "dependencies": {
         "@x-govuk/govuk-prototype-components": "^3.0.6",
-        "govuk-frontend": "5.5.0",
+        "govuk-frontend": "5.6.0",
         "sass": "^1.77.8"
       }
     },
@@ -1652,9 +1652,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.5.0.tgz",
-      "integrity": "sha512-lNSHCOzgk6LfgelcdtJxTLK1BX/cpjCUyEB3LnzliD9o9YQckNMsbj5+jSOs2RFy6XBJ/DJqxj2TKfjBCuzpyA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.6.0.tgz",
+      "integrity": "sha512-yNA4bL7i7mNrg36wPNZ3RctHo9mjl82Phs8MWs1lwovxJuQ4ogEo/XWn2uB1HxkXNqgMlW4wnd0iiKgRMfxYfw==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/guide/package.json
+++ b/guide/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@x-govuk/govuk-prototype-components": "^3.0.6",
-    "govuk-frontend": "5.5.0",
+    "govuk-frontend": "5.6.0",
     "sass": "^1.77.8"
   }
 }

--- a/spec/components/govuk_component/header_component_spec.rb
+++ b/spec/components/govuk_component/header_component_spec.rb
@@ -40,6 +40,19 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
         without_tag('.govuk-header__content')
       end
     end
+
+    specify "the header doesn't have a full width border" do
+      expect(rendered_content).to have_tag('.govuk-header')
+      expect(rendered_content).not_to have_tag('.govuk-header--full-width-border')
+    end
+  end
+
+  context 'when full_width_border is true' do
+    let(:kwargs) { { full_width_border: true } }
+
+    specify 'adds the custom classes to the header container' do
+      expect(rendered_content).to have_tag('header', with: { class: %w(govuk-header govuk-header--full-width-border) })
+    end
   end
 
   context 'customising the container classes' do

--- a/spec/components/govuk_component/service_navigation_component_spec.rb
+++ b/spec/components/govuk_component/service_navigation_component_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe(GovukComponent::ServiceNavigationComponent, type: :component) do
 
   subject! { render_inline(GovukComponent::ServiceNavigationComponent.new(**kwargs)) }
 
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
+  it_behaves_like 'a component that supports custom branding'
+
   specify 'renders a div with the expected attributes' do
     expect(rendered_content).to have_tag("div", with: { class: component_css_class, 'data-module' => 'govuk-service-navigation' })
   end
@@ -205,4 +209,26 @@ RSpec.describe(GovukComponent::ServiceNavigationComponent, type: :component) do
       end
     end
   end
+end
+
+RSpec.describe(GovukComponent::ServiceNavigationComponent::ServiceNameComponent, type: :component) do
+  let(:component_css_class) { 'govuk-service-navigation__service-name' }
+  let(:kwargs) { { service_name: "A service", service_url: "https://a-service.service.gov.uk" } }
+
+  subject! { render_inline(GovukComponent::ServiceNavigationComponent::ServiceNameComponent.new(**kwargs)) }
+
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
+  it_behaves_like 'a component that supports custom branding'
+end
+
+RSpec.describe(GovukComponent::ServiceNavigationComponent::NavigationItemComponent, type: :component) do
+  let(:component_css_class) { 'govuk-service-navigation__item' }
+  let(:kwargs) { { text: "A node", href: "/a-node" } }
+
+  subject! { render_inline(GovukComponent::ServiceNavigationComponent::NavigationItemComponent.new(**kwargs)) }
+
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
+  it_behaves_like 'a component that supports custom branding'
 end

--- a/spec/components/govuk_component/service_navigation_component_spec.rb
+++ b/spec/components/govuk_component/service_navigation_component_spec.rb
@@ -1,0 +1,208 @@
+require 'spec_helper'
+
+RSpec.describe(GovukComponent::ServiceNavigationComponent, type: :component) do
+  let(:component_css_class) { 'govuk-service-navigation' }
+
+  let(:service_name) { nil }
+  let(:service_url) { nil }
+  let(:navigation_items) { [] }
+  let(:current_path) { nil }
+  let(:kwargs) { { service_name:, service_url:, navigation_items:, current_path: } }
+
+  subject! { render_inline(GovukComponent::ServiceNavigationComponent.new(**kwargs)) }
+
+  specify 'renders a div with the expected attributes' do
+    expect(rendered_content).to have_tag("div", with: { class: component_css_class, 'data-module' => 'govuk-service-navigation' })
+  end
+
+  context 'when a service name is present' do
+    let(:service_name) { "My new service" }
+
+    specify 'the outer element is a section with an aria label attribute' do
+      expect(rendered_content).to have_tag("section", with: {
+        class: component_css_class,
+        'data-module' => 'govuk-service-navigation',
+        'aria-label' => 'Service information'
+      })
+    end
+
+    specify 'contains the service name in a span' do
+      expect(rendered_content).to have_tag("section", with: { class: component_css_class }) do
+        with_tag('div', with: { class: 'govuk-service-navigation__container' }) do
+          with_tag('span', class: 'govuk-service-navigation__service-name') do
+            with_tag('span', text: service_name, with: { class: 'govuk-service-navigation__text' })
+          end
+        end
+      end
+    end
+
+    context 'when a service_url is present' do
+      let(:service_url) { "https://my-new.service.gov.uk" }
+
+      specify 'contains a hyperlink with the service name and url' do
+        expect(rendered_content).to have_tag("section", with: { class: component_css_class }) do
+          with_tag('div', with: { class: 'govuk-service-navigation__container' }) do
+            with_tag('span', class: 'govuk-service-navigation__service-name') do
+              with_tag('a', text: service_name, with: { href: service_url, class: 'govuk-service-navigation__link' })
+            end
+          end
+        end
+      end
+    end
+  end
+
+  context 'when navigation items are supplied as an argument' do
+    let(:navigation_items) do
+      [
+        { text: 'Item one', href: '/item-one' },
+        { text: 'Item two', href: '/item-two' },
+      ]
+    end
+
+    specify 'the items are rendered in a list' do
+      expect(rendered_content).to have_tag("div", with: { class: component_css_class }) do
+        with_tag('div', with: { class: 'govuk-service-navigation__container' }) do
+          with_tag('ul', with: { class: 'govuk-service-navigation__list' }) do
+            navigation_items.each do |ni|
+              with_tag('li', with: { class: 'govuk-service-navigation__item' }) do
+                with_tag('a', text: ni.fetch(:text), with: { href: ni.fetch(:href) })
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'when one of the navigation items is current' do
+      let(:navigation_items) do
+        [
+          { text: 'Item one', href: '/item-one' },
+          { text: 'Item two', href: '/item-two', current: true },
+        ]
+      end
+
+      specify 'only the current link is wrapped in a strong element' do
+        expect(rendered_content).to have_tag('li', with: { class: 'govuk-service-navigation__item' }) do
+          with_tag('a', text: 'Item one', with: { href: '/item-one' })
+
+          with_tag('strong', with: { class: 'govuk-service-navigation__active-fallback' }) do
+            with_tag('a', text: 'Item two', with: { href: '/item-two' })
+          end
+        end
+      end
+
+      specify %(the current link has aria-current='page') do
+        expect(rendered_content).to have_tag('a', text: 'Item two', with: { href: '/item-two', 'aria-current' => 'page' })
+      end
+    end
+
+    describe 'matching the current page' do
+      context 'when one of the navigation items matches the current_path' do
+        let(:current_path) { '/admin' }
+        let(:navigation_items) do
+          [
+            { text: 'Admin', href: '/admin' },
+            { text: 'Finance', href: '/finance' },
+          ]
+        end
+
+        specify 'only the matching page is wrapped in a strong element' do
+          expect(rendered_content).to have_tag('li', with: { class: 'govuk-service-navigation__item' }) do
+            with_tag('strong', with: { class: 'govuk-service-navigation__active-fallback' }, count: 1) do
+              with_tag('a', text: 'Admin', with: { href: '/admin' })
+            end
+          end
+        end
+      end
+    end
+
+    context 'when one of the navigation items is active' do
+      let(:navigation_items) do
+        [
+          { text: 'Item one', href: '/item-one' },
+          { text: 'Item two', href: '/item-two', active: true },
+        ]
+      end
+
+      specify 'only the active link is wrapped in a strong element' do
+        expect(rendered_content).to have_tag('li', with: { class: 'govuk-service-navigation__item' }) do
+          with_tag('a', text: 'Item one', with: { href: '/item-one' })
+
+          with_tag('strong', with: { class: 'govuk-service-navigation__active-fallback' }) do
+            with_tag('a', text: 'Item two', with: { href: '/item-two' })
+          end
+        end
+      end
+
+      specify %(the active link has aria-current='true') do
+        expect(rendered_content).to have_tag('a', text: 'Item two', with: { href: '/item-two', 'aria-current' => 'true' })
+      end
+    end
+
+    context 'when active_when is set with a string' do
+      let(:current_path) { '/admin/users/1' }
+      let(:navigation_items) do
+        [
+          { text: 'Admin', href: '/admin', active_when: '/admin' },
+          { text: 'Finance', href: '/finance' },
+        ]
+      end
+
+      specify 'only the active link is wrapped in a strong element' do
+        expect(rendered_content).to have_tag('li', with: { class: 'govuk-service-navigation__item' }) do
+          with_tag('strong', with: { class: 'govuk-service-navigation__active-fallback' }, count: 1) do
+            with_tag('a', text: 'Admin', with: { href: '/admin' })
+          end
+        end
+      end
+
+      specify %(the active link has aria-current='true') do
+        expect(rendered_content).to have_tag('a', text: 'Admin', with: { href: '/admin', 'aria-current' => 'true' })
+      end
+    end
+
+    context 'when active_when is set with an array' do
+      let(:current_path) { '/fr/ventes' }
+      let(:navigation_items) do
+        [
+          { text: 'Admin', href: '/admin' },
+          { text: 'Sales', href: '/sales', active_when: ['/finance', '/fr/ventes'] },
+        ]
+      end
+
+      specify 'only the active link is wrapped in a strong element' do
+        expect(rendered_content).to have_tag('li', with: { class: 'govuk-service-navigation__item' }) do
+          with_tag('strong', with: { class: 'govuk-service-navigation__active-fallback' }, count: 1) do
+            with_tag('a', text: 'Sales', with: { href: '/sales' })
+          end
+        end
+      end
+
+      specify %(the active link has aria-current='true') do
+        expect(rendered_content).to have_tag('a', text: 'Sales', with: { href: '/sales', 'aria-current' => 'true' })
+      end
+    end
+
+    context 'when active_when is set with a regular expression' do
+      let(:current_path) { '/treasure/booty' }
+      let(:navigation_items) do
+        [
+          { text: 'Admin', href: '/admin', active_when: '/admin' },
+          { text: 'Finance', href: '/finance', active_when: %r{^/finance|^/treasure} },
+        ]
+      end
+
+      specify 'only the active link is wrapped in a strong element' do
+        expect(rendered_content).to have_tag('li', with: { class: 'govuk-service-navigation__item' }) do
+          with_tag('strong', with: { class: 'govuk-service-navigation__active-fallback' }, count: 1) do
+            with_tag('a', text: 'Finance', with: { href: '/finance' })
+          end
+        end
+      end
+
+      specify %(the active link has aria-current='true') do
+        expect(rendered_content).to have_tag('a', text: 'Finance', with: { href: '/finance', 'aria-current' => 'true' })
+      end
+    end
+  end
+end


### PR DESCRIPTION
The service navigation component sits beneath the header at the top of the page and contains the service's name and it's primary navigation.

This implementation follows the upstream one very closely but has some additional functionality:

* it accepts a `current_path` argument
* when navigation items match `current_path` exactly they are marked as current
* for pages nested within a section, it accepts a `active_when` argument
* when navigation items begin with the active_when value they are marked as 'active'
* if a regular expression is provided for `active_when`, any positive match results in the node being marked 'active'