### PR TITLE
Upgrade govuk-frontend supported version to 5.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Gem](https://img.shields.io/gem/dt/govuk-components?logo=rubygems)](https://rubygems.org/gems/govuk-components)
 [![Test coverage](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/test_coverage)](https://codeclimate.com/github/x-govuk/govuk-components/test_coverage)
 [![Licence](https://img.shields.io/github/license/x-govuk/govuk-components)](https://github.com/x-govuk/govuk-components/blob/main/LICENSE.txt)
-[![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-5.5.0-brightgreen)](https://design-system.service.gov.uk)
+[![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-5.6.0-brightgreen)](https://design-system.service.gov.uk)
 [![ViewComponent](https://img.shields.io/badge/ViewComponent-3.3.0-brightgreen)](https://viewcomponent.org/)
 [![Rails](https://img.shields.io/badge/Rails-7.0.8%20%E2%95%B1%207.1.3-E16D6D)](https://weblog.rubyonrails.org/releases/)
 [![Ruby](https://img.shields.io/badge/Ruby-3.1.6%20%20%E2%95%B1%203.2.4%20%20%E2%95%B1%203.3.4-E16D6D)](https://www.ruby-lang.org/en/downloads/)

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -23,7 +23,7 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | GOV.UK Design System
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 5.5.0
+        | 5.6.0
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.14.0
     tr.govuk-table__row

--- a/lib/govuk/components/version.rb
+++ b/lib/govuk/components/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Components
-    VERSION = '5.5.0'.freeze
+    VERSION = '5.6.0'.freeze
   end
 end


### PR DESCRIPTION
The actual version bump in the guide happened already in #556
