### PR TITLE
Add custom heading level to summary cards

### DIFF
--- a/app/components/govuk_component/summary_list_component/card_component.html.erb
+++ b/app/components/govuk_component/summary_list_component/card_component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div(**html_attributes) do %>
   <div class="<%= brand %>-summary-card__title-wrapper">
-    <%= tag.h2(title, class: "#{brand}-summary-card__title") %>
+    <%= content_tag(heading_tag, title, class: "#{brand}-summary-card__title") %>
 
     <% if actions.any? %>
       <ul class="<%= brand %>-summary-card__actions">

--- a/app/components/govuk_component/summary_list_component/card_component.html.erb
+++ b/app/components/govuk_component/summary_list_component/card_component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div(**html_attributes) do %>
   <div class="<%= brand %>-summary-card__title-wrapper">
-    <%= content_tag(heading_tag, title, class: "#{brand}-summary-card__title") %>
+    <%= content_tag(heading_level, title, class: "#{brand}-summary-card__title") %>
 
     <% if actions.any? %>
       <ul class="<%= brand %>-summary-card__actions">

--- a/app/components/govuk_component/summary_list_component/card_component.rb
+++ b/app/components/govuk_component/summary_list_component/card_component.rb
@@ -1,11 +1,12 @@
 class GovukComponent::SummaryListComponent::CardComponent < GovukComponent::Base
-  attr_reader :title
+  attr_reader :title, :heading_level
 
   renders_many :actions
   renders_one :summary_list, "GovukComponent::SummaryListComponent"
 
-  def initialize(title:, actions: [], classes: [], html_attributes: {})
+  def initialize(title:, heading_level: 2, actions: [], classes: [], html_attributes: {})
     @title = title
+    @heading_level = heading_level
     actions.each { |a| with_action { a } } if actions.any?
 
     super(classes:, html_attributes:)
@@ -15,6 +16,10 @@ private
 
   def default_attributes
     { class: "#{brand}-summary-card" }
+  end
+
+  def heading_tag
+    "h#{heading_level}"
   end
 
   def action_text(action)

--- a/app/components/govuk_component/summary_list_component/card_component.rb
+++ b/app/components/govuk_component/summary_list_component/card_component.rb
@@ -6,7 +6,7 @@ class GovukComponent::SummaryListComponent::CardComponent < GovukComponent::Base
 
   def initialize(title:, heading_level: 2, actions: [], classes: [], html_attributes: {})
     @title = title
-    @heading_level = heading_level
+    @heading_level = heading_tag(heading_level)
     actions.each { |a| with_action { a } } if actions.any?
 
     super(classes:, html_attributes:)
@@ -18,8 +18,10 @@ private
     { class: "#{brand}-summary-card" }
   end
 
-  def heading_tag
-    "h#{heading_level}"
+  def heading_tag(level)
+    fail(ArgumentError, "heading_level must be 1-6") unless level.in?(1..6)
+
+    "h#{level}"
   end
 
   def action_text(action)

--- a/spec/components/govuk_component/summary_list_card_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_card_component_spec.rb
@@ -80,11 +80,23 @@ RSpec.describe(GovukComponent::SummaryListComponent::CardComponent, type: :compo
   end
 
   context "with a custom heading level" do
-    let(:custom_heading_level) { 3 }
-    before { render_inline(described_class.new(title:, heading_level: custom_heading_level)) }
+    context "when the heading level is valid" do
+      let(:custom_heading_level) { 3 }
+      before { render_inline(described_class.new(title:, heading_level: custom_heading_level)) }
 
-    specify "the card has the right heading level" do
-      expect(rendered_content).to have_tag(%(h#{custom_heading_level}), with: { class: 'govuk-summary-card__title' })
+      specify "the card has the right heading level" do
+        expect(rendered_content).to have_tag(%(h#{custom_heading_level}), with: { class: 'govuk-summary-card__title' })
+      end
+    end
+
+    context "when the heading level is invalid" do
+      let(:custom_heading_level) { 8 }
+
+      specify "has the overriden level" do
+        expected_message = "heading_level must be 1-6"
+
+        expect { described_class.new(title:, heading_level: custom_heading_level) }.to raise_error(ArgumentError, expected_message)
+      end
     end
   end
 

--- a/spec/components/govuk_component/summary_list_card_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_card_component_spec.rb
@@ -79,6 +79,15 @@ RSpec.describe(GovukComponent::SummaryListComponent::CardComponent, type: :compo
     expect(rendered_content).to have_tag("h2", text: title, with: { class: "govuk-summary-card__title" })
   end
 
+  context "with a custom heading level" do
+    let(:custom_heading_level) { 3 }
+    before { render_inline(described_class.new(title:, heading_level: custom_heading_level)) }
+
+    specify "the card has the right heading level" do
+      expect(rendered_content).to have_tag(%(h#{custom_heading_level}), with: { class: 'govuk-summary-card__title' })
+    end
+  end
+
   specify "card contains a summary list" do
     expect(rendered_content).to have_tag("dl", with: { class: "govuk-summary-list" })
   end


### PR DESCRIPTION
This extends the summary card to allow for changing the heading level from the default `h2`