### PR TITLE
Remove paragraph on bundling JS and CSS

### DIFF
--- a/guide/content/introduction/about-viewcomponent.slim
+++ b/guide/content/introduction/about-viewcomponent.slim
@@ -13,10 +13,6 @@ markdown:
   * easier to understand than partials as they are backed by a Ruby object
   * incredibly efficient, [up to 10 times faster than partials](https://viewcomponent.org/#performance)
 
-  They can be extended [to provide custom JavaScript and
-  CSS](https://viewcomponent.org/guide/javascript_and_css.html) too, but this
-  library doesn't do this.
-
   ## Slots
 
   Some components contain elements that are repeated one or many times. For


### PR DESCRIPTION
This page has been removed from the ViewComponent guide and its absence was making our external link checker fail.
