### PR TITLE
Upgrade to govuk-frontend 5.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Gem](https://img.shields.io/gem/dt/govuk-components?logo=rubygems)](https://rubygems.org/gems/govuk-components)
 [![Test coverage](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/test_coverage)](https://codeclimate.com/github/x-govuk/govuk-components/test_coverage)
 [![Licence](https://img.shields.io/github/license/x-govuk/govuk-components)](https://github.com/x-govuk/govuk-components/blob/main/LICENSE.txt)
-[![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-5.8.0-brightgreen)](https://design-system.service.gov.uk)
+[![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-5.9.0-brightgreen)](https://design-system.service.gov.uk)
 [![ViewComponent](https://img.shields.io/badge/ViewComponent-3.16.0-brightgreen)](https://viewcomponent.org/)
 [![Rails](https://img.shields.io/badge/Rails-7.1.5%20%E2%95%B1%207.2.2%20%E2%95%B1%208.0.0-E16D6D)](https://weblog.rubyonrails.org/releases/)
 [![Ruby](https://img.shields.io/badge/Ruby-3.1.6%20%20%E2%95%B1%203.2.6%20%20%E2%95%B1%203.3.6-E16D6D)](https://www.ruby-lang.org/en/downloads/)

--- a/app/components/govuk_component/header_component.rb
+++ b/app/components/govuk_component/header_component.rb
@@ -35,6 +35,12 @@ class GovukComponent::HeaderComponent < GovukComponent::Base
     super(classes:, html_attributes:)
   end
 
+  def before_render
+    if service_name.present? || navigation_items.present?
+      Rails.logger.warn('Service name and navigation links are deprecated and will be removed in the next breaking release of GOV.UK Frontend. See https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0')
+    end
+  end
+
 private
 
   def default_attributes

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -23,7 +23,7 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | GOV.UK Design System
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 5.8.0
+        | 5.9.0
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.14.0
     tr.govuk-table__row

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -24,6 +24,8 @@ use_helper Helpers::TitleAnchorHelpers
 use_helper Helpers::Formatters
 use_helper Helpers::ContentHelpers
 
+Rails.logger = Logger.new($stdout)
+
 $LOAD_PATH.unshift(File.expand_path("../../app", "app"))
 $LOAD_PATH.unshift(File.expand_path("../../lib", "lib"))
 

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -11,7 +11,7 @@
       "license": "ISC",
       "dependencies": {
         "@x-govuk/govuk-prototype-components": "^3.0.6",
-        "govuk-frontend": "5.8.0",
+        "govuk-frontend": "5.9.0",
         "sass": "^1.77.8"
       }
     },
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.8.0.tgz",
-      "integrity": "sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
+      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/guide/package.json
+++ b/guide/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@x-govuk/govuk-prototype-components": "^3.0.6",
-    "govuk-frontend": "5.8.0",
+    "govuk-frontend": "5.9.0",
     "sass": "^1.77.8"
   }
 }


### PR DESCRIPTION
Add a deprecation warning too as the header service name and navigation items functionality will be going away soon.
