### PR TITLE
Allow setting custom licence HTML in footer

### DIFF
--- a/app/components/govuk_component/footer_component.html.erb
+++ b/app/components/govuk_component/footer_component.html.erb
@@ -32,14 +32,14 @@
             </div>
           <% end %>
 
-          <% if meta_licence.nil? %>
+          <% if meta_licence_content.nil? %>
             <svg aria-hidden="true" focusable="false" class="<%= brand %>-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
               <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
             </svg>
 
             <%= tag.span(default_licence, class: "#{brand}-footer__licence-description") %>
-          <% elsif meta_licence.present? %>
-            <%= tag.span(meta_licence, class: "#{brand}-footer__licence-description") %>
+          <% elsif meta_licence_content.present? %>
+            <%= tag.span(meta_licence_content, class: "#{brand}-footer__licence-description") %>
           <% end %>
         </div>
 

--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -6,6 +6,7 @@ class GovukComponent::FooterComponent < GovukComponent::Base
   renders_one :navigation
   renders_one :content_before_meta_items
   renders_one :content_after_meta_items
+  renders_one :meta_licence_html
 
   attr_reader :meta_items, :meta_text, :meta_items_title, :meta_licence, :copyright_text, :copyright_url, :custom_container_classes
 
@@ -45,6 +46,10 @@ private
 
   def meta_content
     meta_html || meta_text
+  end
+
+  def meta_licence_content
+    meta_licence_html || meta_licence
   end
 
   def meta_classes

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -139,19 +139,48 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
       end
     end
 
-    describe "custom meta_licence text" do
-      let(:licence_text) { "Permission is hereby granted, free of charge, to any person obtaining a copy of this software" }
-      let(:kwargs) { { meta_licence: licence_text } }
+    describe "custom licence content" do
       let(:licence_selector) { [selector, ".govuk-footer__licence-description"].join(" ") }
 
-      specify "the custom licence text should be rendered" do
-        expect(rendered_content).to have_tag(licence_selector, text: licence_text)
+      describe "meta_licence" do
+        let(:licence_text) { "Permission is hereby granted, free of charge, to any person obtaining a copy of this software" }
+        let(:kwargs) { { meta_licence: licence_text } }
+
+        specify "the custom licence text should be rendered" do
+          expect(rendered_content).to have_tag(licence_selector, text: licence_text)
+        end
+
+        specify "the licence SVG is not rendered" do
+          expect(rendered_content).to have_tag("footer", with: { class: "govuk-footer" }) do
+            with_tag("div", with: { class: "govuk-footer__meta" }) do
+              without_tag("svg")
+            end
+          end
+        end
       end
 
-      specify "the licence SVG is not rendered" do
-        expect(rendered_content).to have_tag("footer", with: { class: "govuk-footer" }) do
-          with_tag("div", with: { class: "govuk-footer__meta" }) do
-            without_tag("svg")
+      describe "meta_licence_html" do
+        let(:custom_text) { "Some licence HTML" }
+        let(:custom_tag) { "strong" }
+        let(:custom_html) { helper.content_tag(custom_tag, custom_text) }
+
+        subject! do
+          render_inline(GovukComponent::FooterComponent.new(**kwargs)) do |component|
+            component.with_meta_licence_html { custom_html }
+          end
+        end
+
+        specify "the custom licence custom HTML is rendered" do
+          expect(rendered_content).to have_tag(licence_selector) do
+            with_tag(custom_tag, text: Regexp.new(custom_text))
+          end
+        end
+
+        specify "the licence SVG is not rendered" do
+          expect(rendered_content).to have_tag("footer", with: { class: "govuk-footer" }) do
+            with_tag("div", with: { class: "govuk-footer__meta" }) do
+              without_tag("svg")
+            end
           end
         end
       end


### PR DESCRIPTION
There is already an attribute to set custom licence text, however this does not allow including links or a logo, meaning it's not possible to internatialise the footer without removing these items.

Allow passing in `licence_meta_html` as a block to be included instead of the default licence content.

If this change seems sensible, I can attempt to update the documentation.