### PR TITLE
Add the inverse variant of service navigation

### DIFF
--- a/app/components/govuk_component/service_navigation_component.rb
+++ b/app/components/govuk_component/service_navigation_component.rb
@@ -16,14 +16,15 @@ class GovukComponent::ServiceNavigationComponent < GovukComponent::Base
     )
   end
 
-  attr_reader :aria_label_text, :navigation_id
+  attr_reader :aria_label_text, :navigation_id, :inverse
 
-  def initialize(service_name: nil, service_url: nil, navigation_items: [], current_path: nil, aria_label: "Service information", navigation_id: 'navigation', classes: [], html_attributes: {})
+  def initialize(service_name: nil, service_url: nil, navigation_items: [], current_path: nil, aria_label: "Service information", navigation_id: 'navigation', inverse: false, classes: [], html_attributes: {})
     @service_name_text = service_name
     @service_url = service_url
     @current_path = current_path
     @aria_label_text = aria_label
     @navigation_id = navigation_id
+    @inverse = inverse
 
     if @service_name_text.present?
       with_service_name(service_name: @service_name_text, service_url:)
@@ -73,7 +74,13 @@ private
   end
 
   def default_attributes
-    { class: "#{brand}-service-navigation", data: { module: "#{brand}-service-navigation" } }
+    {
+      class: class_names(
+        "#{brand}-service-navigation",
+        "#{brand}-service-navigation--inverse" => inverse,
+      ),
+      data: { module: "#{brand}-service-navigation" },
+    }
   end
 
   def aria_attributes

--- a/guide/content/components/service-navigation.slim
+++ b/guide/content/components/service-navigation.slim
@@ -63,4 +63,12 @@ p
     end of the service navigation. This content needs its own custom styling or it will
     be rendered above and below the other content.
 
+== render('/partials/example.*',
+  caption: "Inverting the service navigation colour",
+  code: service_navigation_with_inverted_colours,
+  data: service_navigation_with_navigation_items_data) do
+
+  markdown:
+    Use `inverse: true` to render the service navigation component with white links on a blue background.
+
 == render('/partials/related-navigation.*', links: service_navigation_info)

--- a/guide/lib/examples/service_navigation_helpers.rb
+++ b/guide/lib/examples/service_navigation_helpers.rb
@@ -85,6 +85,7 @@ module Examples
     def service_navigation_with_inverted_colours
       <<~SNIPPET
         = govuk_service_navigation(inverse: true,
+                                   service_name: 'An inverted service',
                                    navigation_items: navigation_items,
                                    current_path: "/components/header")
       SNIPPET

--- a/guide/lib/examples/service_navigation_helpers.rb
+++ b/guide/lib/examples/service_navigation_helpers.rb
@@ -81,5 +81,13 @@ module Examples
           = sn.with_end_slot { '🌆' }
       SNIPPET
     end
+
+    def service_navigation_with_inverted_colours
+      <<~SNIPPET
+        = govuk_service_navigation(inverse: true,
+                                   navigation_items: navigation_items,
+                                   current_path: "/components/header")
+      SNIPPET
+    end
   end
 end

--- a/spec/components/govuk_component/service_navigation_component_spec.rb
+++ b/spec/components/govuk_component/service_navigation_component_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe(GovukComponent::ServiceNavigationComponent, type: :component) do
   let(:navigation_items) { [] }
   let(:current_path) { nil }
   let(:navigation_id) { nil }
-  let(:kwargs) { { service_name:, service_url:, navigation_items:, current_path:, navigation_id: }.compact }
+  let(:inverse) { false }
+  let(:kwargs) { { service_name:, service_url:, navigation_items:, current_path:, navigation_id:, inverse: }.compact }
 
   subject! { render_inline(GovukComponent::ServiceNavigationComponent.new(**kwargs)) }
 
@@ -243,6 +244,44 @@ RSpec.describe(GovukComponent::ServiceNavigationComponent, type: :component) do
 
       specify %(the active link has aria-current='true') do
         expect(rendered_content).to have_tag('a', text: 'Finance', with: { href: '/finance', 'aria-current' => 'true' })
+      end
+    end
+  end
+
+  describe 'inverting the colours' do
+    let(:inverse_class) { 'govuk-service-navigation--inverse' }
+    let(:inverse_class_selector) { '.' + inverse_class }
+
+    context 'when inverse is not set' do
+      let(:inverse) { nil }
+
+      it 'renders the component without the inverse class' do
+        expect(rendered_content).not_to have_tag(inverse_class_selector)
+      end
+    end
+
+    context 'when inverse is false' do
+      let(:inverse) { false }
+
+      it 'renders the component without the inverse class' do
+        expect(rendered_content).not_to have_tag(inverse_class_selector)
+      end
+    end
+
+    context 'when inverse is true' do
+      let(:inverse) { true }
+
+      it 'renders the component with the inverse class' do
+        expect(rendered_content).to have_tag("div", with: { class: [component_css_class, inverse_class], 'data-module' => 'govuk-service-navigation' })
+      end
+    end
+
+    context 'when a service name is present and inverse is true' do
+      let(:service_name) { 'A very nice service' }
+      let(:inverse) { true }
+
+      it 'renders the component with the inverse class' do
+        expect(rendered_content).to have_tag("section", with: { class: [component_css_class, inverse_class], 'data-module' => 'govuk-service-navigation' })
       end
     end
   end


### PR DESCRIPTION
This adds support for the [inverse variant](https://govuk-frontend-review.herokuapp.com/components/service-navigation#heading-inverse) of the service nav component.


## Preview

![image](https://github.com/user-attachments/assets/4312ccef-dfdb-4885-a4e7-f6ff98ff4e29)


## Notes

Looks a bit weird when there's a service name on it too. I'd expect the service name to be white here :thinking: 

Did I miss something in the markup?

![Screenshot From 2025-06-24 22-56-41](https://github.com/user-attachments/assets/006e51b0-88a0-47ed-9fb4-390b0e2c3ea0)
