### PR TITLE
Fix 'exit this page now' previews

### DIFF
--- a/guide/content/stylesheets/preview.scss
+++ b/guide/content/stylesheets/preview.scss
@@ -89,3 +89,10 @@
   align-items: center;
   gap: 1em;
 }
+
+// Isolate the preview from the rest of the page so components that only
+// contain floating elements (i.e. the exit this page component) maintain
+// height
+.app-scoped-preview {
+  contain: layout;
+}


### PR DESCRIPTION
The exit this page now component consists of a div that is set to `float: right` with a link in it. Floating elements don't contribute to their container's height so the preview box is squashed.

Using [`contain: layout`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain#layout) isolates the element from the rest of the page and stops the floating element from overhanging the preview box.

| Before | After |
| ---- | ---- |
| ![Screenshot From 2025-07-05 16-02-01](https://github.com/user-attachments/assets/8d17b32d-47c5-453e-b3f6-bfa7fd306573) |![Screenshot From 2025-07-05 16-02-20](https://github.com/user-attachments/assets/dd54bf97-4cf5-4503-9c43-c14a165506de) |
