### PR TITLE
Upgrade to ViewComponent 4.0.0

### DIFF
--- a/app/components/govuk_component/base.rb
+++ b/app/components/govuk_component/base.rb
@@ -23,7 +23,7 @@ class GovukComponent::Base < ViewComponent::Base
       .deep_merge_html_attributes(html_attributes)
       .deep_tidy_html_attributes
 
-    super
+    super()
   end
 
   def brand(override = nil)

--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("html-attributes-utils", "~> 1.0.0", ">= 1.0.0")
   spec.add_dependency("pagy", ">= 6", "< 10")
-  spec.add_dependency("view_component", ">= 3.18", "< 3.24")
+  spec.add_dependency("view_component", ">= 4.0", "< 4.1")
 
   spec.add_development_dependency "deep_merge"
   spec.add_development_dependency "ostruct"

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -26,7 +26,6 @@ module Dummy
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
-    config.view_component.preview_paths << Rails.root.join("lib/components/previews")
     config.view_component.default_preview_layout = "preview"
   end
 end


### PR DESCRIPTION
The default initializer was removed from ViewComponent::Base so call it without arguments.

Fixes #608 