### PR TITLE
Remove all traces of CodeClimate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,28 +53,6 @@ jobs:
       - name: Run Rubocop
         run: make ruby-lint
 
-      - name: Download CodeClimate reporter
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-          ./cc-test-reporter before-build
-
-      - name: Run RSpec
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-          SIMPLECOV: '1'
-        run: make rspec
-
-      - name: Report coverage to CodeClimate
-        continue-on-error: true
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-          GIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
-          GIT_COMMIT_SHA: ${{ github.sha }}
-        run: ./cc-test-reporter after-build -t simplecov
-
       - name: Run Nanoc Check
         run: make nanoc-check-all
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,5 @@ watch-guide: npm-install
 	( ${guide_dir} ${prefix} nanoc live --port ${nanoc_default_port} )
 docs-server:
 	yard server --reload
-code-climate:
-	codeclimate analyze {lib,spec,guide/lib}
 clean:
 	rm -rf guide/output/**/*

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # GOV.UK Components for Ruby on Rails
 
 [![Tests](https://github.com/x-govuk/govuk-components/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/x-govuk/govuk-components/actions/workflows/tests.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/maintainability)](https://codeclimate.com/github/x-govuk/govuk-components/maintainability)
 [![Gem version](https://badge.fury.io/rb/govuk-components.svg)](https://badge.fury.io/rb/govuk-components)
 [![Gem](https://img.shields.io/gem/dt/govuk-components?logo=rubygems)](https://rubygems.org/gems/govuk-components)
-[![Test coverage](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/test_coverage)](https://codeclimate.com/github/x-govuk/govuk-components/test_coverage)
 [![Licence](https://img.shields.io/github/license/x-govuk/govuk-components)](https://github.com/x-govuk/govuk-components/blob/main/LICENSE.txt)
 [![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-5.11.0-brightgreen)](https://design-system.service.gov.uk)
 [![ViewComponent](https://img.shields.io/badge/ViewComponent-3.24.0-brightgreen)](https://viewcomponent.org/)

--- a/guide/layouts/partials/footer.slim
+++ b/guide/layouts/partials/footer.slim
@@ -16,9 +16,6 @@ footer.govuk-footer
           li.govuk-footer__inline-list-item
             a.govuk-footer__link href=documentation_link
               | RubyDoc documentation
-          li.govuk-footer__inline-list-item
-            a.govuk-footer__link href=code_climate_report_link
-              | Code Climate report
 
         span.govuk-footer__licence-description
           | Licensed under the #{link_to('MIT License', licence_link, class: "govuk-footer__link").html_safe}, except where otherwise stated

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -71,10 +71,6 @@ module Helpers
       'https://www.rubydoc.info/gems/govuk-components/'
     end
 
-    def code_climate_report_link
-      'https://codeclimate.com/github/x-govuk/govuk-components'
-    end
-
     def dfe_rails_boilerplate_link
       'https://github.com/DFE-Digital/govuk-rails-boilerplate'
     end


### PR DESCRIPTION
It's been rebranded as https://qlty.sh/ - might re-add it but for now just get rid as it's making the build fail.
