### PR TITLE
Defer helper usage in Footer, Action and Accordion components for VC4

### DIFF
--- a/app/components/govuk_component/accordion_component.rb
+++ b/app/components/govuk_component/accordion_component.rb
@@ -16,9 +16,13 @@ class GovukComponent::AccordionComponent < GovukComponent::Base
 
   def initialize(heading_level: 2, classes: [], html_attributes: {})
     @heading_level = heading_tag(heading_level)
-    @accordion_id  = html_attributes[:id]
 
     super(classes:, html_attributes:)
+  end
+
+  def before_render
+    super
+    @accordion_id = html_attributes[:id]
   end
 
   def call

--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -25,7 +25,7 @@ class GovukComponent::FooterComponent < GovukComponent::Base
     meta_html_attributes: {}
   )
     @meta_text                        = meta_text
-    @meta_items                       = build_meta_links(meta_items)
+    @raw_meta_items                   = meta_items
     @meta_items_title                 = meta_items_title
     @meta_licence                     = meta_licence
     @custom_meta_classes              = meta_classes
@@ -35,7 +35,16 @@ class GovukComponent::FooterComponent < GovukComponent::Base
     @custom_container_classes         = container_classes
     @custom_container_html_attributes = container_html_attributes
 
+    unless meta_items.blank? || meta_items.is_a?(Hash) || meta_items.is_a?(Array)
+      raise ArgumentError, 'meta links must be a hash or array of hashes'
+    end
+
     super(classes:, html_attributes:)
+  end
+
+  def before_render
+    super
+    @meta_items = build_meta_links(@raw_meta_items)
   end
 
 private
@@ -75,11 +84,11 @@ private
 
     case links
     when Array
-      links.map { |link| govuk_footer_link_to(link[:text], link[:href], **link.fetch(:attr, {})) }
+      links.map { |link| helpers.govuk_footer_link_to(link[:text], link[:href], **link.fetch(:attr, {})) }
     when Hash
-      links.map { |text, href| govuk_footer_link_to(text, href) }
+      links.map { |text, href| helpers.govuk_footer_link_to(text, href) }
     else
-      fail(ArgumentError, 'meta links must be a hash or array of hashes') unless links.is_a?(Hash)
+      raise ArgumentError, 'meta links must be a hash or array of hashes'
     end
   end
 

--- a/app/components/govuk_component/summary_list_component/action_component.rb
+++ b/app/components/govuk_component/summary_list_component/action_component.rb
@@ -19,7 +19,10 @@ class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Ba
   end
 
   def call
-    link_to(href, **html_attributes) do
+    attrs = html_attributes.dup
+    attrs[:class] = safe_join([helpers.govuk_link_classes, classes, attrs[:class]].compact, " ")
+
+    link_to(href, **attrs) do
       safe_join([action_text, visually_hidden_span].compact)
     end
   end
@@ -27,9 +30,7 @@ class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Ba
 private
 
   def default_attributes
-    link_classes = safe_join([govuk_link_classes, classes], " ")
-
-    { class: link_classes }
+    {}
   end
 
   def action_text

--- a/app/components/govuk_component/summary_list_component/action_component.rb
+++ b/app/components/govuk_component/summary_list_component/action_component.rb
@@ -19,10 +19,7 @@ class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Ba
   end
 
   def call
-    attrs = html_attributes.dup
-    attrs[:class] = safe_join([helpers.govuk_link_classes, classes, attrs[:class]].compact, " ")
-
-    link_to(href, **attrs) do
+    link_to(href, **html_attributes) do
       safe_join([action_text, visually_hidden_span].compact)
     end
   end
@@ -30,7 +27,8 @@ class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Ba
 private
 
   def default_attributes
-    {}
+    link_classes = safe_join(["#{brand}-link", classes], " ")
+    { class: link_classes }
   end
 
   def action_text


### PR DESCRIPTION
## Summary

This PR updates `govuk-components` to be compatible with **ViewComponent v4** by deferring all helper usage until render time.

## Changes

- **FooterComponent**
  - Store raw `meta_items` in `initialize`.
  - Defer building meta links until `before_render`.
  - Add type check in `initialize` to raise if `meta_items` is not a hash/array (keeps existing spec passing).

- **SummaryList::ActionComponent**
  - Move `govuk_link_classes` call out of `default_attributes`.
  - Compute link classes in `call` instead, where helpers are available.
  - `default_attributes` now returns `{}`.

- **AccordionComponent**
  - Defer reading `html_attributes[:id]` until `before_render`.
  - Prevents accessing view context–dependent state in `initialize`.

## Why

ViewComponent v4 removed the default initializer and no longer provides the view context during `initialize` or `default_attributes`. Any use of helpers in those methods raises errors.

These changes ensure helpers (`govuk_link_classes`, `govuk_footer_link_to`, etc.) are only called during `before_render` or `call`, where the view context is available.

## References

- [ViewComponent v4 changelog](https://github.com/ViewComponent/view_component/releases/tag/v4.0.0)

  > Remove default initializer from ViewComponent::Base.  
  > Remove dependency on ActionView::Base, eliminating the need for capture compatibility patch.  
  > In some edge cases, this change may require switching to use the `helpers` proxy.
