### PR TITLE
Include helpers in the components that use them

### DIFF
--- a/app/components/govuk_component/exit_this_page_component.rb
+++ b/app/components/govuk_component/exit_this_page_component.rb
@@ -1,4 +1,7 @@
 class GovukComponent::ExitThisPageComponent < GovukComponent::Base
+  include GovukLinkHelper
+  include GovukVisuallyHiddenHelper
+
   attr_reader :text, :redirect_url, :activated_text, :timed_out_text, :press_two_more_times_text, :press_one_more_time_text
 
   def initialize(

--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -1,4 +1,6 @@
 class GovukComponent::FooterComponent < GovukComponent::Base
+  include GovukLinkHelper
+
   using HTMLAttributesUtils
 
   renders_one :meta_html

--- a/app/components/govuk_component/summary_list_component/action_component.rb
+++ b/app/components/govuk_component/summary_list_component/action_component.rb
@@ -1,4 +1,7 @@
 class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Base
+  include GovukLinkHelper
+  include GovukVisuallyHiddenHelper
+
   attr_reader :href, :text, :visually_hidden_text, :visually_hidden_action_suffix, :attributes, :classes
 
   def initialize(href: nil, text: 'Change', visually_hidden_text: false, visually_hidden_action_suffix: nil, classes: [], html_attributes: {})

--- a/app/components/govuk_component/task_list_component/title_component.rb
+++ b/app/components/govuk_component/task_list_component/title_component.rb
@@ -1,5 +1,8 @@
 module GovukComponent
   class TaskListComponent::TitleComponent < GovukComponent::Base
+    include GovukLinkHelper
+    include GovukVisuallyHiddenHelper
+
     using HTMLAttributesUtils
 
     attr_reader :id_prefix, :text, :href, :hint, :count

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -42,11 +42,6 @@ require 'govuk/components'
 #        https://github.com/ViewComponent/view_component/issues/1565
 ViewComponent::Base.config.view_component_path = "app/components"
 
-# rubocop:disable Style/MixinUsage
-include GovukVisuallyHiddenHelper
-include GovukLinkHelper
-# rubocop:enable Style/MixinUsage
-
 require 'components/govuk_component'
 require 'components/govuk_component/traits'
 require 'components/govuk_component/traits/custom_html_attributes'
@@ -100,6 +95,8 @@ require 'components/govuk_component/warning_text_component'
 require 'helpers/govuk_link_helper'
 require 'helpers/govuk_visually_hidden_helper'
 
+use_helper GovukVisuallyHiddenHelper
+use_helper GovukLinkHelper
 use_helper GovukComponentsHelper
 use_helper Examples::LinkHelpers
 use_helper Examples::AccordionHelpers
@@ -129,3 +126,6 @@ use_helper Examples::BackToTopLinkHelpers
 use_helper Examples::TitleWithErrorPrefixHelpers
 use_helper Examples::VisuallyHiddenHelpers
 use_helper Examples::ListHelpers
+
+ActiveSupport.on_load(:action_view) { include GovukVisuallyHiddenHelper }
+ActiveSupport.on_load(:action_view) { include GovukLinkHelper }


### PR DESCRIPTION
Since 4.0, ViewComponent recommends to [either include helper modules or use the helpers proxy](https://github.com/ViewComponent/view_component/releases/tag/v4.0.0). This change updates the components so they include the relevant helpers.

